### PR TITLE
add dep ensure to running locally

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -39,6 +39,7 @@ kubectl create namespace eunomia
 kubectl apply -f ./deploy/crds/eunomia_v1alpha1_gitopsconfig_crd.yaml -n eunomia
 export JOB_TEMPLATE=./templates/job.yaml
 export CRONJOB_TEMPLATE=./templates/cronjob.yaml
+dep ensure
 operator-sdk up local
 ```
 


### PR DESCRIPTION
# Pull Request Template

## Description

The currently flow of the development documentation has `dep ensure` coming after the `running locally` section. When I went through the documentation top down, I received a compilation error due to not running `dep ensure`. 

Either we can add `dep ensure` where I have or restructure the flow of the document some.

Fixes #(issue)

I did not open an issue.

Please delete options that are not relevant.

* Bug fix
* This change requires a documentation update

