### PR TITLE
fix typo and wrong repo URL for helm example

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ oc apply -f ./deploy/openshift -n eunomia-operator
 
 ## Examples / Demos
 
-We've created several examples for you to test our Eunomonia. See [EXAMPLES](examples/README.md) for details.
+We've created several examples for you to test out Eunomonia. See [EXAMPLES](examples/README.md) for details.
 
 ## Development
 

--- a/examples/hello-world-helm/cr/hello-world-cr1.yaml
+++ b/examples/hello-world-helm/cr/hello-world-cr1.yaml
@@ -4,7 +4,7 @@ metadata:
   name: hello-world-helm
 spec:
   templateSource:
-    uri: https://github.com/Smiley73/eunomia
+    uri: https://github.com/KohlsTechnology/eunomia
     ref: master
     contextDir: examples/hello-world-helm/templates
   parameterSource:

--- a/examples/hello-world-helm/cr/hello-world-cr2.yaml
+++ b/examples/hello-world-helm/cr/hello-world-cr2.yaml
@@ -4,7 +4,7 @@ metadata:
   name: hello-world-helm
 spec:
   templateSource:
-    uri: https://github.com/Smiley73/eunomia
+    uri: https://github.com/KohlsTechnology/eunomia
     ref: master
     contextDir: examples/hello-world-helm/templates
   parameterSource:

--- a/examples/hello-world-helm/cr/hello-world-cr3.yaml
+++ b/examples/hello-world-helm/cr/hello-world-cr3.yaml
@@ -4,7 +4,7 @@ metadata:
   name: hello-world-helm
 spec:
   templateSource:
-    uri: https://github.com/Smiley73/eunomia
+    uri: https://github.com/KohlsTechnology/eunomia
     ref: master
     contextDir: examples/hello-world-helm/templates
   parameterSource:


### PR DESCRIPTION
## Description

One of my previous PRs introduces a minor typo and the wrong URL for the CRs. This PR correct's it.

## Type of change

* Bug fix (non-breaking change which fixes an issue)
