### PR TITLE
Fix Travis CI release deployment automation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+## v0.0.2 (Unreleased)
+This release has the same content as release v0.0.1. A bug
+was found in the Travis CI automation that prevented the v0.0.1
+container images from being pushed to quay.io.
+
+## v0.0.1 (August 28, 2019)
+* Initial release
+* Dead on arrival, do not use

--- a/scripts/build-images.sh
+++ b/scripts/build-images.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash -e
+#!/usr/bin/env bash
 
 # Copyright 2019 Kohl's Department Stores, Inc.
 #
@@ -13,6 +13,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+set -e
 
 REPOSITORY=${1}
 if [ -z "${TRAVIS_TAG}" ] ; then


### PR DESCRIPTION
## Description

Make Travis CI release deployment automation work.

Fixes #83 

## Type of change

Please delete options that are not relevant.

* Bug fix (non-breaking change which fixes an issue)

## Environment

* Runtime version(Java, Go, Python, etc): n/a
