### PR TITLE
helm-release -- WIP

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,10 @@ env:
   - OPERATOR_SDK_VERSION=v0.8.1 KUBE_VERSION=v1.14.2
 
 before_install:
+  - if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then openssl aes-256-cbc -K $encrypted_fa8b1278af8d_key -iv $encrypted_fa8b1278af8d_iv -in github_deploy_key.enc -out github_deploy_key -d; fi
+  - if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then chmod 600 github_deploy_key; fi
+  - if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then eval $(ssh-agent -s); fi
+  - if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then ssh-add github_deploy_key; fi  
   - travis_retry go mod vendor
   - go get golang.org/x/lint/golint
 
@@ -46,7 +50,7 @@ deploy:
       branch: master
   - provider: script
     skip_cleanup: true
-    script: make travis-deploy-images
+    script: make travis-release-deploy
     on:
       repo: KohlsTechnology/eunomia
       tags: true

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,12 @@ BUILD_COMMIT := $(shell ./scripts/build/get-build-commit.sh)
 BUILD_TIMESTAMP := $(shell ./scripts/build/get-build-timestamp.sh)
 BUILD_HOSTNAME := $(shell ./scripts/build/get-build-hostname.sh)
 
+export GITHUB_PAGES_DIR ?= /tmp/helm/publish
+export GITHUB_PAGES_BRANCH ?= gh-pages
+export GITHUB_PAGES_REPO ?= KohlsTechnology/eunomia
+export HELM_CHARTS_SOURCE ?= deploy/helm
+export HELM_CHART_DEST ?= $(GITHUB_PAGES_DIR)
+
 LDFLAGS := "-X github.com/KohlsTechnology/eunomia/version.Version=$(VERSION) \
 	-X github.com/KohlsTechnology/eunomia/version.Vcs=$(BUILD_COMMIT) \
 	-X github.com/KohlsTechnology/eunomia/version.Timestamp=$(BUILD_TIMESTAMP) \
@@ -52,3 +58,10 @@ generate:
 travis-deploy-images:
 	docker login -u ${DOCKER_USER} -p ${DOCKER_PASSWORD} ${REGISTRY}
 	./scripts/build-images.sh ${REPOSITORY}
+
+publish-chart-repo:
+	./scripts/build/checkout-rebase-pages.sh 
+	./scripts/build/build-chart-repo.sh 
+	./scripts/build/push-to-pages.sh 
+
+travis-release-deploy: travis-deploy-images	publish-chart-repo

--- a/scripts/build/build-chart-repo.sh
+++ b/scripts/build/build-chart-repo.sh
@@ -1,0 +1,13 @@
+echo '>> Building charts...'
+find "$HELM_CHARTS_SOURCE" -mindepth 1 -maxdepth 1 -type d | while read chart; do
+  version=${TRAVIS_TAG} envsubst < $chart/values.yaml.tpl > $chart/values.yaml
+  version=${TRAVIS_TAG} envsubst < $chart/Chart.yaml.tpl  > $chart/Chart.yaml
+  echo ">>> helm lint $chart"
+  helm lint "$chart"
+  chart_dest=$HELM_CHART_DEST/"`basename "$chart"`"
+  echo ">>> helm package -d $chart_dest $chart"
+  mkdir -p "$chart_dest"
+  helm package -d "$chart_dest" "$chart"
+done
+echo '>>>' "helm repo index --url https://$(dirname $GITHUB_PAGES_REPO).github.io/$(basename $GITHUB_PAGES_REPO) $HELM_CHART_DEST"
+helm repo index --url https://$(dirname $GITHUB_PAGES_REPO).github.io/$(basename $GITHUB_PAGES_REPO) $HELM_CHART_DEST

--- a/scripts/build/checkout-rebase-pages.sh
+++ b/scripts/build/checkout-rebase-pages.sh
@@ -1,0 +1,5 @@
+echo GITHUB_PAGES_DIR: $GITHUB_PAGES_DIR
+mkdir -p $GITHUB_PAGES_DIR
+echo ">> Checking out $GITHUB_PAGES_BRANCH branch from $GITHUB_PAGES_REPO"
+# git -C $GITHUB_PAGES_DIR clone -b "$GITHUB_PAGES_BRANCH" "https://github.com/$GITHUB_PAGES_REPO" .
+git -C $GITHUB_PAGES_DIR clone -b "$GITHUB_PAGES_BRANCH" "git@github.com:$GITHUB_PAGES_REPO.git" .

--- a/scripts/build/push-to-pages.sh
+++ b/scripts/build/push-to-pages.sh
@@ -1,0 +1,8 @@
+git -C $GITHUB_PAGES_DIR config user.email "travis@users.noreply.github.com"
+git -C $GITHUB_PAGES_DIR config user.name travis
+# git -C $GITHUB_PAGES_DIR config credential.helper 'store --file ~/.travis.git.credentials'
+# echo https://$GIT_USERNAME:$GIT_PASSWORD@github.com >> ~/.travis.git.credentials
+git -C $GITHUB_PAGES_DIR add .
+git -C $GITHUB_PAGES_DIR status
+git -C $GITHUB_PAGES_DIR commit -m "Published by Travis"
+git -C $GITHUB_PAGES_DIR push origin "$GITHUB_PAGES_BRANCH"


### PR DESCRIPTION
This PR automates the creation of helm template at release time.
This is a very difficult type of change to test because I cannot/don't want to trigger a release.

This is a WIP until the following is done:

1. github pages is enabled using the `gh-pages` branch, see [here](https://help.github.com/en/articles/configuring-a-publishing-source-for-github-pages)
2. a deploy key is created for travis to be able to push to the `gh-pages` branch. see [here](https://gist.github.com/qoomon/c57b0dc866221d91704ffef25d41adcf) and [here](https://medium.com/@simon.legner/deploy-to-github-pages-using-travis-ci-and-deploy-keys-db84fed7a929) on how to do it.

once you have the key and the name of the hidden encryption variables set up in travis, please send them to me. I will add them to this PR.