### PR TITLE
Work around go mod error for git.apache.org/thrift.git

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -60,3 +60,6 @@ replace (
 	sigs.k8s.io/controller-runtime => sigs.k8s.io/controller-runtime v0.1.10
 	sigs.k8s.io/controller-tools => sigs.k8s.io/controller-tools v0.1.11-0.20190411181648-9d55346c2bde
 )
+
+// Work around issue wtih git.apache.org/thrift.git
+replace git.apache.org/thrift.git => github.com/apache/thrift v0.12.0


### PR DESCRIPTION
## Description

The code will now compile again. In the future we should
consider vendoring our dependencies.

Fixes #90 

## Type of change

* Bug fix (non-breaking change which fixes an issue)

## Environment

* Runtime version(Java, Go, Python, etc):

Go Lang 1.12
