### PR TITLE
Fix hardcoded v0.0.1 & "latest" tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ env:
   - GO111MODULE=on
   - CHANGE_MINIKUBE_NONE_USER=true
   matrix:
-  - OPERATOR_SDK_VERSION=v0.8.1 KUBE_VERSION=v1.14.2
+  - OPERATOR_SDK_VERSION=v0.8.1 KUBE_VERSION=v1.14.2 MINIKUBE_VERSION=v1.3.1
 
 before_install:
   - travis_retry go mod vendor
@@ -17,7 +17,7 @@ before_install:
 before_script:
 - curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/${KUBE_VERSION}/bin/linux/amd64/kubectl
 - sudo chmod +x kubectl && sudo mv kubectl /usr/local/bin/
-- curl -Lo minikube https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64
+- curl -Lo minikube https://storage.googleapis.com/minikube/releases/${MINIKUBE_VERSION}/minikube-linux-amd64
 - sudo chmod +x minikube && sudo mv minikube /usr/local/bin/
 - curl -LO https://git.io/get_helm.sh && chmod 700 get_helm.sh && ./get_helm.sh
 - curl -OJL https://github.com/operator-framework/operator-sdk/releases/download/${OPERATOR_SDK_VERSION}/operator-sdk-${OPERATOR_SDK_VERSION}-x86_64-linux-gnu

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,6 @@ script:
   - golint -set_exit_status $(go list ./... | grep -v /vendor/)
   - bash scripts/unit-tests.sh
   - bash scripts/e2e-test.sh
-  - make travis-test-images
 
 deploy:
   - provider: script

--- a/Makefile
+++ b/Makefile
@@ -48,8 +48,8 @@ vet:
 generate:
 	go generate ./pkg/... ./cmd/...
 
-travis-test-images: manager
-	./scripts/build-images.sh ${REPOSITORY}
+e2e-test-images: manager
+	TRAVIS_TAG=v999.0.0 ./scripts/build-images.sh ${REPOSITORY}
 
 # Deploy images to Quay.io
 travis-deploy-images: manager

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 REGISTRY ?= quay.io
 REPOSITORY ?= $(REGISTRY)/kohlstechnology
 
-VERSION := v0.0.1
+VERSION := $(shell ./scripts/build/get-version.sh)
 
 BUILD_COMMIT := $(shell ./scripts/build/get-build-commit.sh)
 BUILD_TIMESTAMP := $(shell ./scripts/build/get-build-timestamp.sh)

--- a/deploy/helm/operator/eunomia-templates/cronjob.yaml
+++ b/deploy/helm/operator/eunomia-templates/cronjob.yaml
@@ -11,7 +11,7 @@ spec:
         spec:
           containers:
           - name: template-processor
-            imagePullPolicy: Always
+            imagePullPolicy: IfNotPresent
             image: {{ .Config.Spec.TemplateProcessorImage }}
             env:
             - name: NAMESPACE

--- a/deploy/helm/operator/eunomia-templates/job.yaml
+++ b/deploy/helm/operator/eunomia-templates/job.yaml
@@ -10,7 +10,7 @@ spec:
     spec:                                                    
       containers:
       - name: template-processor
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         image: {{ .Config.Spec.TemplateProcessorImage }}
         env:
         - name: HOME

--- a/examples/simple/templates/template.yaml
+++ b/examples/simple/templates/template.yaml
@@ -15,7 +15,7 @@ objects:
     serviceAccountName: eunomia-operator
     containers:
     - image: hello-world:latest
-      imagePullPolicy: Always
+      imagePullPolicy: IfNotPresent
       name: helloworld
       ports:
       - containerPort: 8080

--- a/scripts/build-images.sh
+++ b/scripts/build-images.sh
@@ -18,7 +18,7 @@ set -e
 
 REPOSITORY=${1}
 if [ -z "${TRAVIS_TAG}" ] ; then
-    IMAGE_TAG="latest"
+    IMAGE_TAG="dev"
 else
     IMAGE_TAG=${TRAVIS_TAG}
 fi
@@ -26,31 +26,54 @@ fi
 PUSH_IMAGES=${2:+true}
 
 # Builds (and optionally pushes) a single image.
-# Usage: build_image <context dir> <image url> <push image (0=true, 1=false)>
-# Example: build_image template-processors/myimage quay.io/KohlsTechnology/myimage:latest 0
+# Usage: build_image <context dir> <image name>
+# Example: build_image template-processors/myimage/ myimage
 build_image() {
-  context_dir=$1
-  image_url=$2
-  push=${3:-false}
-  docker build ${context_dir} -t ${image_url}
-  if $push; then docker push $image_url; fi
+  local context_dir=$1
+  local image_url=${REPOSITORY}/$2
+  local push=${PUSH_IMAGES:-false}
+
+  # Make sure "dev" docker tag always points to the most recently changed commit
+  docker build "${context_dir}" -t "${image_url}:dev"
+  if $push; then
+      docker push "${image_url}:dev"
+  fi
+
+  # If adjusting a git tag, set the appropriate tag in docker as well
+  if [ "${IMAGE_TAG}" != "dev" ]; then
+      docker tag "${image_url}:dev" "${image_url}:${IMAGE_TAG}"
+      if $push; then
+          docker push "${image_url}:${IMAGE_TAG}"
+      fi
+  fi
+
+  # Do we have to move the "latest" tag in the docker repository?
+  # Do it only if the newly tagged version is the newest one in git, according to basic SemVer semantics (vMAJOR.MINOR.PATCH).
+  local latest=v$(git tag --list "v[0-9]*" | sed 's/^v//' | sort -t . -n -k 1,1 -k 2,2 -k 3,3 -r | head -n1)
+  if [ "${IMAGE_TAG}" = "${latest}" ]; then
+      docker tag "${image_url}:${IMAGE_TAG}" "${image_url}:latest"
+      if $push; then
+          docker push "${image_url}:latest"
+      fi
+  fi
 }
 
 # building and pushing the operator images
-build_image build ${REPOSITORY}/eunomia-operator:${IMAGE_TAG} ${PUSH_IMAGES}
+build_image build/ eunomia-operator
 
 # building and pushing base template processor images
-build_image template-processors/base ${REPOSITORY}/eunomia-base:${IMAGE_TAG} ${PUSH_IMAGES}
+build_image template-processors/base/ eunomia-base
 
 # building and pushing helm template processor images
-build_image template-processors/helm ${REPOSITORY}/eunomia-helm:${IMAGE_TAG} ${PUSH_IMAGES}
+build_image template-processors/helm/ eunomia-helm
 
 # building and pushing OCP template processor images
-build_image template-processors/ocp-template ${REPOSITORY}/eunomia-ocp-templates:${IMAGE_TAG} ${PUSH_IMAGES}
+build_image template-processors/ocp-template/ eunomia-ocp-templates
 
 # building and pushing Applier template processor image
 # NOTE: this is based on the OCP template image, so this build must always come after that.
-build_image template-processors/applier ${REPOSITORY}/eunomia-applier:${IMAGE_TAG} ${PUSH_IMAGES}
+build_image template-processors/applier/ eunomia-applier
 
 # building and pushing jinja template processor images
-build_image template-processors/jinja ${REPOSITORY}/eunomia-jinja:${IMAGE_TAG} ${PUSH_IMAGES}
+build_image template-processors/jinja/ eunomia-jinja
+

--- a/scripts/build-images.sh
+++ b/scripts/build-images.sh
@@ -33,6 +33,13 @@ build_image() {
   local image_url=${REPOSITORY}/$2
   local push=${PUSH_IMAGES:-false}
 
+  if [ -f "${context_dir}/Dockerfile.in" ]; then
+      cat "${context_dir}/Dockerfile.in" |
+          sed "s|@REPOSITORY@|${REPOSITORY}|g" |
+          sed "s|@IMAGE_TAG@|${IMAGE_TAG}|g" \
+          > "${context_dir}/Dockerfile"
+  fi
+
   # Make sure "dev" docker tag always points to the most recently changed commit
   docker build "${context_dir}" -t "${image_url}:dev"
   if $push; then

--- a/scripts/build/get-build-commit.sh
+++ b/scripts/build/get-build-commit.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
 GIT_SHA=$(git rev-parse --short HEAD)
 

--- a/scripts/build/get-version.sh
+++ b/scripts/build/get-version.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
 GIT_V_TAG=$(git tag --list 'v[0-9]*' --points-at HEAD)
 

--- a/scripts/build/get-version.sh
+++ b/scripts/build/get-version.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+GIT_V_TAG=$(git tag --list 'v[0-9]*' --points-at HEAD)
+
+if [ "$GIT_V_TAG" ]; then
+    echo "$GIT_V_TAG"
+else
+    echo "dev-$(git rev-parse --short HEAD)"
+fi
+

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -31,6 +31,11 @@ if [[ $(kubectl get namespace $TEST_NAMESPACE) ]]; then
     kubectl delete namespace $TEST_NAMESPACE
 fi
 
+# Pre-populate the Docker registry in minikube with images built from the current commit
+# See also: https://stackoverflow.com/q/42564058
+eval $(minikube docker-env)
+make e2e-test-images
+
 helm template deploy/helm/prereqs/ \
   --set eunomia.operator.namespace=$TEST_NAMESPACE | kubectl apply -f -
 

--- a/template-processors/applier/Dockerfile.in
+++ b/template-processors/applier/Dockerfile.in
@@ -1,4 +1,4 @@
-FROM quay.io/kohlstechnology/eunomia-ocp-templates:latest
+FROM @REPOSITORY@/eunomia-ocp-templates:@IMAGE_TAG@
 
 ENV OPENSHIFT_MODULE_VERSION=0.9.0
 ENV KUBE_MODULE_VERSION=9.0.0

--- a/template-processors/helm/Dockerfile.in
+++ b/template-processors/helm/Dockerfile.in
@@ -1,4 +1,4 @@
-FROM quay.io/kohlstechnology/eunomia-base:latest
+FROM @REPOSITORY@/eunomia-base:@IMAGE_TAG@
 
 ENV HELM_VERSION="v2.14.3"
 

--- a/template-processors/jinja/Dockerfile.in
+++ b/template-processors/jinja/Dockerfile.in
@@ -1,4 +1,4 @@
-FROM quay.io/kohlstechnology/eunomia-base:latest
+FROM @REPOSITORY@/eunomia-base:@IMAGE_TAG@
 
 USER root
 RUN pip install j2cli[yaml]

--- a/template-processors/ocp-template/Dockerfile.in
+++ b/template-processors/ocp-template/Dockerfile.in
@@ -1,4 +1,4 @@
-FROM quay.io/kohlstechnology/eunomia-base:latest
+FROM @REPOSITORY@/eunomia-base:@IMAGE_TAG@
 
 ENV OC_VERSION=4.1.8
 

--- a/test/e2e/helm_template_test.go
+++ b/test/e2e/helm_template_test.go
@@ -71,7 +71,7 @@ func helmTestDeploy(t *testing.T, f *framework.Framework, ctx *framework.TestCtx
 				},
 			},
 			ResourceDeletionMode:   "Delete",
-			TemplateProcessorImage: "quay.io/kohlstechnology/eunomia-helm:latest",
+			TemplateProcessorImage: "quay.io/kohlstechnology/eunomia-helm:dev",
 			ResourceHandlingMode:   "CreateOrMerge",
 			ServiceAccountRef:      "eunomia-operator",
 		},

--- a/test/e2e/ocp_template_test.go
+++ b/test/e2e/ocp_template_test.go
@@ -72,7 +72,7 @@ func ocpTemplateTestDeploy(t *testing.T, f *framework.Framework, ctx *framework.
 				},
 			},
 			ResourceDeletionMode:   "Delete",
-			TemplateProcessorImage: " quay.io/kohlstechnology/eunomia-ocp-templates:latest",
+			TemplateProcessorImage: " quay.io/kohlstechnology/eunomia-ocp-templates:dev",
 			ResourceHandlingMode:   "CreateOrMerge",
 			ServiceAccountRef:      "eunomia-operator",
 		},

--- a/test/namespace-init.yaml
+++ b/test/namespace-init.yaml
@@ -86,7 +86,7 @@ spec:
       containers:
         - name: eunomia-operator
           # Replace this with the built image name
-          image: quay.io/kohlstechnology/eunomia-operator:latest
+          image: quay.io/kohlstechnology/eunomia-operator:dev
           command:
           - eunomia-operator
           imagePullPolicy: Always
@@ -162,7 +162,7 @@ spec:
       containers:
         - name: eunomia-operator
           # Replace this with the built image name
-          image: quay.io/kohlstechnology/eunomia-operator:latest
+          image: quay.io/kohlstechnology/eunomia-operator:dev
           command:
           - eunomia-operator
           imagePullPolicy: Always

--- a/test/namespace-init.yaml
+++ b/test/namespace-init.yaml
@@ -89,7 +89,7 @@ spec:
           image: quay.io/kohlstechnology/eunomia-operator:dev
           command:
           - eunomia-operator
-          imagePullPolicy: Always
+          imagePullPolicy: IfNotPresent
           env:
             - name: JOB_TEMPLATE
               value: /templates/job.yaml
@@ -165,7 +165,7 @@ spec:
           image: quay.io/kohlstechnology/eunomia-operator:dev
           command:
           - eunomia-operator
-          imagePullPolicy: Always
+          imagePullPolicy: IfNotPresent
           env:
             - name: JOB_TEMPLATE
               value: /templates/job.yaml


### PR DESCRIPTION
## Description

Fix hardcoded `v0.0.1` and `latest` tags in various places:
- github.com/KohlsTechnology/eunomia/version.Version
- docker image tags on quay.io

As a result of the fix, the tagging policy on quay.io is changed as follows:
- "latest" tag — will be always pointing to the newest official release [Note: this fix will get applied only starting from the next vX.Y.Z release]
- "dev" tag — will be pointing to an image built from the most recently pushed commit in the GitHub repository.

Fixes #64

## Type of change

* Bug fix (non-breaking change which fixes an issue)
* This change requires a documentation update

