### PR TITLE
Use latest Go 1.12.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: required
 language: go
 go_import_path: github.com/KohlsTechnology/eunomia
 go:
-- "1.12"
+- "1.12.x"
 env:
   global:
   - GO111MODULE=on

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## v0.0.2 (Unreleased)
 * Fix release automation
 * Add OpenShift Applier template processor
+* Use latest Go Lang 1.12.x version
 
 ## v0.0.1 (August 28, 2019)
 * Initial release

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/KohlsTechnology/eunomia
 
+go 1.12
+
 require (
 	contrib.go.opencensus.io/exporter/ocagent v0.4.9 // indirect
 	github.com/Azure/go-autorest v11.5.2+incompatible // indirect


### PR DESCRIPTION
## Description

Use latest Go 1.12.x version

## Type of change

* Bug fix (non-breaking change which fixes an issue)

## Environment

* Runtime version(Java, Go, Python, etc):

Go 1.12.x
