### PR TITLE
Remove DEFAULT_ROUTE_DOMAIN and REGISTRY_ROUTE environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,6 @@ The base image provides the following workflow:
     |:---|:---|
     | `CA_BUNDLE`  | Platform-level CA bundle  |
     | `SERVICE_CA_BUNDLE`  | Service-level CA bundle  |
-    | `DEFAULT_ROUTE_DOMAIN`  | Base route domain for the default router  |
     | `NAMESPACE`  | Current namespace  |
 3. `processParameters.sh` : This script processes all the parameter files and generates a `eunomia_values_processed.yaml` in the location specified by `CLONED_PARAMETER_GIT_DIR`. This script currently supports the following features:
     - Merging of all existing yaml files in the `CLONED_PARAMETER_GIT_DIR` location, into a single file for processing by the templating engine. 

--- a/template-processors/base/bin/discoverEnvironment.sh
+++ b/template-processors/base/bin/discoverEnvironment.sh
@@ -32,11 +32,6 @@ function getClusterCAs {
     echo export SERVICE_CA_BUNDLE=$(kube get secret $SECRET -n default -o "jsonpath={.data['service-ca\.crt']}") >> $HOME/envs.sh
 }
 
-function getDefaultRouteDomain {
-    REGISTRY_ROUTE=$(kube get route docker-registry --no-headers -n default | awk '{print $2}')
-    echo export DEFAULT_ROUTE_DOMAIN=${REGISTRY_ROUTE#*.} >> $HOME/envs.sh
-}
-
 function getNamespace {
     echo export NAMESPACE=$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace) >> $HOME/envs.sh
 }
@@ -44,5 +39,4 @@ function getNamespace {
 echo Setting cluster-related environment variable
 setContext
 getClusterCAs
-getDefaultRouteDomain
 getNamespace


### PR DESCRIPTION
## Description

This PR removes getDefaultRouteDomain function from discoverEnvironment.sh
script in base template processor because it's not clear why is that
implemented and current implementation fails on kubernetes.

With current implementation hello-world example on Minikube fails with following error: 
```
Cloning Repositories
Cloning into '/git/templates'...
Cloning into '/git/parameters'...
Setting cluster-related environment variable
Context "current" created.
Switched to context "current".
error: the server doesn't have a resource type "route"
Processing Parameters
ERROR - missing parameter files
```

## Type of change

* Bug fix (non-breaking change which fixes an issue)

## Environment

* Runtime version(Java, Go, Python, etc): base
