### PR TITLE
add fix to set a home directory in the passwd file so that when entry…

### DIFF
--- a/template-processors/base/Dockerfile
+++ b/template-processors/base/Dockerfile
@@ -6,7 +6,8 @@ ENV USER_UID=1001 \
     KUBECTL_VERSION="v1.15.0" \
     YQ_VERSION="2.7.2" \
     GOLANG_YQ_VERSION="2.4.0" \
-    JQ_VERSION="1.6"
+    JQ_VERSION="1.6" \
+    HOME=/tmp
 
 COPY bin /usr/local/bin
 

--- a/template-processors/base/bin/gitClone.sh
+++ b/template-processors/base/bin/gitClone.sh
@@ -31,13 +31,19 @@ function pullFromTemplatesRepo {
   then
     no_proxy=$TEMPLATE_GIT_NO_PROXY
   fi
-  if [ -z "$TEMPLATE_GITCONFIG" ] && [ -d "$TEMPLATE_GITCONFIG" ]
+  if [ -n "$TEMPLATE_GITCONFIG" ] && [ -d "$TEMPLATE_GITCONFIG" ]
   then
     for file in $TEMPLATE_GITCONFIG/*; do
-      cp -f $file ~/$(basename $file)
+      if [ -e "$file" ]
+      then
+        cp -f $file ~/$(basename $file)
+      fi
     done
     for file in $TEMPLATE_GITCONFIG/.git*; do
-      cp -f $file ~/$(basename $file)
+      if [ -e "$file" ]
+      then
+        cp -f $file ~/$(basename $file)
+      fi
     done      
   else
    export GIT_SSL_NO_VERIFY=true


### PR DESCRIPTION
…point runs the home directory is used for the user so that the copy scripts for git config will work

# Pull Request Template

## Description

Add HOME environment variable to the base Docker file so that when the user is added to the passwd file a directory is used that the container will have write access to and thus allow gitconfig files to be copied to appropriate places

Fixes #130

## Type of change

* Bug fix (non-breaking change which fixes an issue)

## Environment

* Runtime version(Java, Go, Python, etc): All/base image
