### PR TITLE
Test dev and latest image tags

### DIFF
--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -47,3 +47,24 @@ operator-sdk test local ./test/e2e --namespace "$TEST_NAMESPACE" --up-local --no
 helm template deploy/helm/eunomia-operator/ \
   --set eunomia.operator.deployment.enabled= \
   --set eunomia.operator.namespace=$TEST_NAMESPACE | kubectl delete -f -
+
+helm template deploy/helm/eunomia-operator/ \
+  --set eunomia.operator.image.tag=dev \
+  --set eunomia.operator.namespace=$TEST_NAMESPACE | kubectl apply -f -
+
+sleep 30
+
+podname=$(kubectl get pods  -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' -n $TEST_NAMESPACE)
+
+if kubectl exec "${podname}" date -n $TEST_NAMESPACE
+then
+  echo "Pod is Healthy"
+else
+  echo "Pod is not Healthy"
+  exit 1
+fi
+
+helm template deploy/helm/eunomia-operator/ \
+  --set eunomia.operator.image.tag=dev \
+  --set eunomia.operator.namespace=$TEST_NAMESPACE | kubectl delete -f -
+


### PR DESCRIPTION
##  Description

It will add the capability to test image 

This commit is added so that we can automatically catch issues like  #107 in the future.
It verifies "dev" tag eunomia operator container image from quay.io can be successfully started in a minikube cluster.

## Type of change

* New feature (non-breaking change which adds functionality)


## Environment

* Runtime version(Java, Go, Python, etc):
