### PR TITLE
.github: redesign ISSUE_TEMPLATE.md based on one in golang repository

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,27 +1,35 @@
-(While submitting an issue briefly describe the problem you are facing or a new feature you would want to see added) 
+<!-- Please answer these questions before submitting your issue. Thanks! -->
 
-## What happens?
+### What version of eunomia are you using?
 
-...
+eunomia version:
 
-## What were you expecting to happen?
+### Does this issue reproduce with the latest release?
 
-...
 
-## Steps to reproduce: 
 
-* ...
-* ...
+### What operating system and processor architecture are you using (`kubectl version`)?
 
-## Any errors, stacktrace, logs? 
+<details><summary><code>kubectl version</code> Output</summary><br><pre>
+$ kubectl version
 
-...
+</pre></details>
 
-## Environment:
+### What did you do?
 
-* Runtime version(Java, Go, Python, etc):
-* Desktop OS/version:
+<!--
+If possible, provide a recipe for reproducing the error.
+A detailed sequence of steps describing what to do to observe the issue is good.
+A complete runnable bash shell script is best.
+-->
 
-## Additional comments:
 
-...
+
+### What did you expect to see?
+
+
+
+### What did you see instead?
+
+
+


### PR DESCRIPTION
# Pull Request Template

## Description

The order of questions in the old template had some issues.
Specifically, a reporter trying to answer them in order, if they wanted
to provide some basic context, would have to repeat a lot of information
between the answers. For example, to answer "What happens?" question,
a reporter might want to start by describing what they did. Which
duplicates the work they'd then have to do in "Steps to reproduce"
section, without clear guidance as to how to structure the answer or how
much detail to provide.

This commit changes the template, based on ISSUE_TEMPLATE.md from
https://github.com/golang/go repository, adapted to our case. The
questions in this one are laid in such an order, that answers to the
earlier ones provide context on which the answers further down can
easily build, without repeating information.


## Type of change

Please delete options that are not relevant.

* Bug fix (non-breaking change which fixes an issue)

