### PR TITLE
chore: limit branches built by Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+branches:
+  only:
+  - master
+  - /^v\d+\.\d+\.\d+$/
 sudo: required
 language: go
 go_import_path: github.com/KohlsTechnology/eunomia


### PR DESCRIPTION
<!-- Please fill in each section below to help us better prioritize your pull request. Thanks! -->

**Description**

Prior to this pull request each pull request would trigger two builds in
Travis CI, one for the pull request and one for the branch. Both Travis
CI builds were running the exact same steps. This is very wasteful.

Travis CI only needs to build the master branch and GitHub releases.

No change to pull requests builds.

See Travis CI docs:
https://docs.travis-ci.com/user/customizing-the-build/#safelisting-or-blocklisting-branches

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
This PR is not related to an open issue.

**Type of change**

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)
