### PR TITLE
Add stricter error detection flags in bash scripts

### DIFF
--- a/template-processors/applier/bin/processTemplates.sh
+++ b/template-processors/applier/bin/processTemplates.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 
-set -o nounset
-set -o errexit
+set -euxo pipefail
 
 cd $CLONED_TEMPLATE_GIT_DIR/
 ansible-galaxy install -r requirements.yml -p galaxy

--- a/template-processors/applier/bin/processTemplates.sh
+++ b/template-processors/applier/bin/processTemplates.sh
@@ -1,5 +1,19 @@
 #!/usr/bin/env bash
 
+# Copyright 2019 Kohl's Department Stores, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 set -euxo pipefail
 
 cd $CLONED_TEMPLATE_GIT_DIR/

--- a/template-processors/base/bin/discoverEnvironment.sh
+++ b/template-processors/base/bin/discoverEnvironment.sh
@@ -14,8 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -o nounset
-set -o errexit
+set -euxo pipefail
 
 function setContext {
   $kubectl config set-context current --namespace=$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace)
@@ -27,6 +26,12 @@ function kube {
 }
 
 function getClusterCAs {
+    if ! kube describe sa default -n default 2>&1 >/dev/null; then
+        echo "FIXME: 'kube describe sa default -n default' is not working"
+        echo export CA_BUNDLE= >> $HOME/envs.sh
+        echo export SERVICE_CA_BUNDLE= >> $HOME/envs.sh
+        return
+    fi
     SECRET=$(kube describe sa default -n default | grep 'Tokens:' | awk '{print $2}')
     echo export CA_BUNDLE=$(kube get secret $SECRET -n default -o "jsonpath={.data['ca\.crt']}") >> $HOME/envs.sh
     echo export SERVICE_CA_BUNDLE=$(kube get secret $SECRET -n default -o "jsonpath={.data['service-ca\.crt']}") >> $HOME/envs.sh

--- a/template-processors/base/bin/entrypoint
+++ b/template-processors/base/bin/entrypoint
@@ -1,4 +1,5 @@
-#!/bin/sh -e
+#!/bin/env bash
+set -euxo pipefail
 
 # This is documented here:
 # https://docs.openshift.com/container-platform/3.11/creating_images/guidelines.html#openshift-specific-guidelines

--- a/template-processors/base/bin/entrypoint
+++ b/template-processors/base/bin/entrypoint
@@ -1,4 +1,19 @@
 #!/bin/env bash
+
+# Copyright 2019 Kohl's Department Stores, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 set -euxo pipefail
 
 # This is documented here:

--- a/template-processors/base/bin/gitClone.sh
+++ b/template-processors/base/bin/gitClone.sh
@@ -30,17 +30,17 @@ function pullFromTemplatesRepo {
   then
     local no_proxy="$TEMPLATE_GIT_NO_PROXY"
   fi
-  if [ -z "$TEMPLATE_GITCONFIG" ] && [ -d "$TEMPLATE_GITCONFIG" ]
+  if [ "$TEMPLATE_GITCONFIG" ] && [ -d "$TEMPLATE_GITCONFIG" ]
   then
-    for file in $TEMPLATE_GITCONFIG/*; do
-      cp -f $file ~/$(basename $file)
+    for file in "$TEMPLATE_GITCONFIG"/*; do
+      cp -f "$file" "~/$(basename $file)"
     done
-    for file in $TEMPLATE_GITCONFIG/.git*; do
-      cp -f $file ~/$(basename $file)
-    done      
+    for file in "$TEMPLATE_GITCONFIG"/.git*; do
+      cp -f "$file" "~/$(basename $file)"
+    done
   else
-   export GIT_SSL_NO_VERIFY=true
-  fi 
+    export GIT_SSL_NO_VERIFY=true
+  fi
   set -u
   mkdir -p $TEMPLATE_GIT_DIR
   (
@@ -65,17 +65,17 @@ function pullFromParametersRepo {
   then
     local no_proxy="$PARAMETER_GIT_NO_PROXY"
   fi
-  if [ -z "$PARAMETER_GITCONFIG" ] && [ -d "$PARAMETER_GITCONFIG" ]
+  if [ "$PARAMETER_GITCONFIG" ] && [ -d "$PARAMETER_GITCONFIG" ]
   then 
-    for file in $TEMPLATE_GITCONFIG/*; do
-      cp -f $file ~/$(basename $file)
+    for file in "$PARAMETER_GITCONFIG"/*; do
+      cp -f "$file" "~/$(basename $file)"
     done
-    for file in $TEMPLATE_GITCONFIG/.git*; do
-      cp -f $file ~/$(basename $file)
-    done    
+    for file in "$PARAMETER_GITCONFIG"/.git*; do
+      cp -f "$file" "~/$(basename $file)"
+    done
   else
-   export GIT_SSL_NO_VERIFY=true
-  fi    
+    export GIT_SSL_NO_VERIFY=true
+  fi
   set -u
   mkdir -p $PARAMETER_GIT_DIR
   (

--- a/template-processors/base/bin/gitClone.sh
+++ b/template-processors/base/bin/gitClone.sh
@@ -18,20 +18,16 @@ set -euxo pipefail
 
 function pullFromTemplatesRepo {
   set +u
-  if [ ! -z "$TEMPLATE_GIT_HTTP_PROXY" ] 
-  then
+  if [ "$TEMPLATE_GIT_HTTP_PROXY" ]; then
     local http_proxy="$TEMPLATE_GIT_HTTP_PROXY"
   fi
-  if [ ! -z "$TEMPLATE_GIT_HTTPS_PROXY" ] 
-  then
+  if [ "$TEMPLATE_GIT_HTTPS_PROXY" ]; then
     local https_proxy="$TEMPLATE_GIT_HTTPS_PROXY"
-  fi 
-  if [ ! -z "$TEMPLATE_GIT_NO_PROXY" ] 
-  then
+  fi
+  if [ "$TEMPLATE_GIT_NO_PROXY" ]; then
     local no_proxy="$TEMPLATE_GIT_NO_PROXY"
   fi
-  if [ "$TEMPLATE_GITCONFIG" ] && [ -d "$TEMPLATE_GITCONFIG" ]
-  then
+  if [ "$TEMPLATE_GITCONFIG" ] && [ -d "$TEMPLATE_GITCONFIG" ]; then
     for file in "$TEMPLATE_GITCONFIG"/*; do
       cp -f "$file" "~/$(basename $file)"
     done
@@ -53,20 +49,16 @@ function pullFromTemplatesRepo {
 
 function pullFromParametersRepo {
   set +u
-  if [ ! -z "$PARAMETER_GIT_HTTP_PROXY" ] 
-  then
+  if [ "$PARAMETER_GIT_HTTP_PROXY" ]; then
     local http_proxy="$PARAMETER_GIT_HTTP_PROXY"
   fi
-  if [ ! -z "$PARAMETER_GIT_HTTPS_PROXY" ] 
-  then
+  if [ "$PARAMETER_GIT_HTTPS_PROXY" ]; then
     local https_proxy="$PARAMETER_GIT_HTTPS_PROXY"
-  fi 
-  if [ ! -z "$PARAMETER_GIT_NO_PROXY" ] 
-  then
+  fi
+  if [ "$PARAMETER_GIT_NO_PROXY" ]; then
     local no_proxy="$PARAMETER_GIT_NO_PROXY"
   fi
-  if [ "$PARAMETER_GITCONFIG" ] && [ -d "$PARAMETER_GITCONFIG" ]
-  then 
+  if [ "$PARAMETER_GITCONFIG" ] && [ -d "$PARAMETER_GITCONFIG" ]; then
     for file in "$PARAMETER_GITCONFIG"/*; do
       cp -f "$file" "~/$(basename $file)"
     done

--- a/template-processors/base/bin/gitClone.sh
+++ b/template-processors/base/bin/gitClone.sh
@@ -14,8 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -o nounset
-set -o errexit
+set -euxo pipefail
 
 function pullFromTemplatesRepo {
   set +u

--- a/template-processors/base/bin/processParameters.sh
+++ b/template-processors/base/bin/processParameters.sh
@@ -14,8 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -o nounset
-set -o errexit
+set -euxo pipefail
 
 echo Processing Parameters
 

--- a/template-processors/base/bin/processTemplates.sh
+++ b/template-processors/base/bin/processTemplates.sh
@@ -14,8 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -o nounset
-set -o errexit
+set -euxo pipefail
 
 echo Processing Templates
 

--- a/template-processors/base/bin/resourceManager.sh
+++ b/template-processors/base/bin/resourceManager.sh
@@ -31,9 +31,7 @@ function deleteResources {
     for file in $(find $MANIFEST_DIR -iregex '.*\.yaml'); do
       cat $file | yq 'select(.kind == "GitOpsConfig")' | kube delete -f - --wait=true
     done
-    set +u
     kube delete -R -f $MANIFEST_DIR
-    set -u
 }
 
 function createUpdateResources {
@@ -41,9 +39,7 @@ function createUpdateResources {
     kube apply -R -f $MANIFEST_DIR
   fi
   if [ $CREATE_MODE == "CreateOrUpdate" ]; then
-    set +u
     kube create -R -f $MANIFEST_DIR
-    set -u
     kube update -R -f $MANIFEST_DIR
   fi
   if [ $CREATE_MODE == "Patch" ]; then

--- a/template-processors/base/bin/resourceManager.sh
+++ b/template-processors/base/bin/resourceManager.sh
@@ -14,8 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -o nounset
-set -o errexit
+set -euxo pipefail
 
 # this is needed becasue we want the current namespace to be set as default if a namespace is not specified.
 function setContext {

--- a/template-processors/base/bin/wrapper.sh
+++ b/template-processors/base/bin/wrapper.sh
@@ -14,8 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -o nounset
-set -o errexit
+set -euxo pipefail
 
 export HOME=/tmp
 /usr/local/bin/gitClone.sh

--- a/template-processors/helm/bin/processTemplates.sh
+++ b/template-processors/helm/bin/processTemplates.sh
@@ -14,8 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -o nounset
-set -o errexit
+set -euxo pipefail
 
 ## we assume in $CLONED_TEMPLATE_GIT_DIR there is a helm chart
 ## the helm chart may need updating

--- a/template-processors/jinja/bin/processTemplates.sh
+++ b/template-processors/jinja/bin/processTemplates.sh
@@ -1,5 +1,19 @@
 #!/usr/bin/env bash
 
+# Copyright 2019 Kohl's Department Stores, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 set -euxo pipefail
 
 ## we assume in $CLONED_TEMPLATE_GIT_DIR there are a set of templates with a .j2 extension

--- a/template-processors/jinja/bin/processTemplates.sh
+++ b/template-processors/jinja/bin/processTemplates.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 
-set -o nounset
-set -o errexit
+set -euxo pipefail
 
 ## we assume in $CLONED_TEMPLATE_GIT_DIR there are a set of templates with a .j2 extension
 ## we assume that in $CLONED_PARAMETER_GIT_DIR there is a parameter file called parameters.yaml

--- a/template-processors/ocp-template/bin/processTemplates.sh
+++ b/template-processors/ocp-template/bin/processTemplates.sh
@@ -14,8 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -o nounset
-set -o errexit
+set -euxo pipefail
 
 ## we assume in $CLONED_TEMPLATE_GIT_DIR there is a template called template.yaml
 ## we assume that in $CLONED_PARAMETER_GIT_DIR there is a parameter file called parameters.ini


### PR DESCRIPTION
<!-- Please fill in each section below to help us better prioritize your pull request. Thanks! -->

**Description**

<!-- Please provide a summary of the change here. -->

This PR adds error detection flags (`set -euo pipefail`) in all bash scripts I was able to find in the repository, that were missing it before. This will improve robustness of the scripts.

Adding those flags resulted in a failing command being found in `discoverEnvironment.sh`. The PR adds a temporary workaround, and I opened a separate issue #152 with regards to fixing the underlying problem in the future.

Additionally, the PR enables execution tracing (`set -x`) in most of the scripts, including template-processors base scripts. This is intended to help when any debugging of the scripts is needed, and make it easier for contributors to provide better logs when reporting issues.



<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Closes #74 

**Type of change**

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)

