### PR TITLE
Make proxy in eunomia-base work

### DIFF
--- a/template-processors/base/bin/gitClone.sh
+++ b/template-processors/base/bin/gitClone.sh
@@ -21,15 +21,15 @@ function pullFromTemplatesRepo {
   set +u
   if [ ! -z "$TEMPLATE_GIT_HTTP_PROXY" ] 
   then
-    http_proxy=$TEMPLATE_GIT_HTTP_PROXY
+    local http_proxy="$TEMPLATE_GIT_HTTP_PROXY"
   fi
   if [ ! -z "$TEMPLATE_GIT_HTTPS_PROXY" ] 
   then
-    https_proxy=$TEMPLATE_GIT_HTTPS_PROXY
+    local https_proxy="$TEMPLATE_GIT_HTTPS_PROXY"
   fi 
   if [ ! -z "$TEMPLATE_GIT_NO_PROXY" ] 
   then
-    no_proxy=$TEMPLATE_GIT_NO_PROXY
+    local no_proxy="$TEMPLATE_GIT_NO_PROXY"
   fi
   if [ -z "$TEMPLATE_GITCONFIG" ] && [ -d "$TEMPLATE_GITCONFIG" ]
   then
@@ -44,22 +44,27 @@ function pullFromTemplatesRepo {
   fi 
   set -u
   mkdir -p $TEMPLATE_GIT_DIR
-  git clone -b $TEMPLATE_GIT_REF $TEMPLATE_GIT_URI $TEMPLATE_GIT_DIR
+  (
+    export http_proxy
+    export https_proxy
+    export no_proxy
+    git clone -b "$TEMPLATE_GIT_REF" "$TEMPLATE_GIT_URI" "$TEMPLATE_GIT_DIR"
+  )
 }
 
 function pullFromParametersRepo {
   set +u
   if [ ! -z "$PARAMETER_GIT_HTTP_PROXY" ] 
   then
-    http_proxy=$PARAMETER_GIT_HTTP_PROXY
+    local http_proxy="$PARAMETER_GIT_HTTP_PROXY"
   fi
   if [ ! -z "$PARAMETER_GIT_HTTPS_PROXY" ] 
   then
-    https_proxy=$PARAMETER_GIT_HTTPS_PROXY
+    local https_proxy="$PARAMETER_GIT_HTTPS_PROXY"
   fi 
   if [ ! -z "$PARAMETER_GIT_NO_PROXY" ] 
   then
-    no_proxy=$PARAMETER_GIT_NO_PROXY
+    local no_proxy="$PARAMETER_GIT_NO_PROXY"
   fi
   if [ -z "$PARAMETER_GITCONFIG" ] && [ -d "$PARAMETER_GITCONFIG" ]
   then 
@@ -74,7 +79,12 @@ function pullFromParametersRepo {
   fi    
   set -u
   mkdir -p $PARAMETER_GIT_DIR
-  git clone -b $PARAMETER_GIT_REF $PARAMETER_GIT_URI $PARAMETER_GIT_DIR
+  (
+    export http_proxy
+    export https_proxy
+    export no_proxy
+    git clone -b "$PARAMETER_GIT_REF" "$PARAMETER_GIT_URI" "$PARAMETER_GIT_DIR"
+  )
 }
 
 echo Cloning Repositories


### PR DESCRIPTION
Export http_proxy, https_proxy, and no_proxy for them to have effect
on git (they must be env variables in order to work).

Make the variables local to functions and export them in subshells in
order not to affect the whole script scope - envs from function
pullFromTemplatesRepo don't affect those from function
pullFromParametersRepo and vice versa.

<!-- Please fill in each section below to help us better prioritize your pull request. Thanks! -->

**Description**

<!-- Please provide a summary of the change here. -->

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #154 

**Type of change**

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)
