### PR TITLE
Use kubernetes wait flag instead of sleep

### DIFF
--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -52,7 +52,7 @@ helm template deploy/helm/eunomia-operator/ \
   --set eunomia.operator.image.tag=dev \
   --set eunomia.operator.namespace=$TEST_NAMESPACE | kubectl apply -f -
 
-sleep 30
+kubectl wait --for=condition=available --timeout=30s deployment/eunomia-operator -n $TEST_NAMESPACE
 
 podname=$(kubectl get pods  -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' -n $TEST_NAMESPACE)
 


### PR DESCRIPTION
**Description**
kubectl wait flag, waits until the specified condition is seen in the Status field of every given
resource. 
It has few advantages over sleep like, if specified condition is met before the mentioned timeout it will continue to next step , rather waiting for entire specified time . 

Fixes (#107 )

**Type of change**
* New feature (non-breaking change which adds functionality)
