### PR TITLE
Add python-passlib to support ansible htpasswd module in applier template processor

### DIFF
--- a/template-processors/applier/Dockerfile.in
+++ b/template-processors/applier/Dockerfile.in
@@ -6,7 +6,7 @@ ENV KUBE_MODULE_VERSION=9.0.0
 USER root
 
 RUN yum install -y --disableplugin=subscription-manager python36-devel gcc python3-pip python3-setuptools && \
-    pip3 install ansible openshift==$OPENSHIFT_MODULE_VERSION kubernetes==$KUBE_MODULE_VERSION jmespath && \
+    pip3 install ansible openshift==$OPENSHIFT_MODULE_VERSION kubernetes==$KUBE_MODULE_VERSION jmespath passlib && \
     yum remove -y gcc python36-devel
 
 COPY bin/processTemplates.sh /usr/local/bin/processTemplates.sh


### PR DESCRIPTION
**Description**

In order to use the [ansible htpasswd](https://docs.ansible.com/ansible/latest/modules/htpasswd_module.html#requirements) module in the applier template processor image, [PassLib](https://bitbucket.org/ecollins/passlib) has to be installed.

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #(issue)

**Type of change**

<!-- Please delete options that are not relevant. -->

* New feature (non-breaking change which adds functionality)
