### PR TITLE
chore: include commit message standards in PR template

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,22 +1,69 @@
- Contributing to Eunomia
+## Contributing to Eunomia
 
-Eunomia project is licensed under [Apache 2.0 license](LICENSE) and is open for contributions mainly via GitHub pull requests. 
+The Eunomia project is licensed under [Apache 2.0 license](LICENSE) and is open for contributions via GitHub pull requests. 
 
-## How to Contribute
+### How to Contribute
 
-You can contribute to the project by submitting Pull Requests (PRs), submitting Issues that you found which will help us improve Eunomia, or by suggesting new features.
+You can contribute to this project by submitting pull requests, or by submitting issues for bugs/enhancemnts that you
+found which will help us improve Eunomia.
 
-When submitting a Pull Request, we expect that it will pass following requirements:
+When submitting a pull request, we expect that it will meet following requirements:
 
-- Your code must be written in an idiomatic Go.
-- Formatted in accordance with the [gofmt](https://golang.org/cmd/gofmt).
-- [go lint](https://github.com/golang/lint) shouldn't produce any warnings, same as [go vet](https://golang.org/cmd/vet)
-- If you are submitting PR with a new feature, code should be covered with the suite of unit tests that test new functionality. Same rule applies for PRs that are bug fixes.
+- Code must be written using [idiomatic Go](https://golang.org/doc/effective_go.html).
+- Code must be formatted using [gofmt](https://golang.org/cmd/gofmt).
+- Code must not produce [go lint](https://github.com/golang/lint) errors or warnings.
+- Code must not produce [go vet](https://golang.org/cmd/vet) errors or warnings.
+- All code changes are covered by the suite of unit and e2e tests.
 
-### Commit message format
+### Commit Message Format
 
-Every commit message should contain information about package under which the changes were applied, short summary of the implemented changes and GitHub issue it relates to (if applicable):
+Every commit message should contain information about Go package under which the changes were applied, a short summary of the implemented changes and the GitHub issue it relates to (if applicable).
 
 ```
-<package>: <what has changed> [Fixes #<issue-number>]
+<package>: <short commit message>
+
+Detailed commit message explaining why the code is being changed.
+
+Fixes #<issue-number>
+```
+
+Example commit message.
+```
+main: add HTTP timeout to GitHub webhook
+
+Prior to this change the net/http webserver used by the GitHub webhook
+did not enforce an HTTP tiemout. Misbehaving HTTP clients could hold open
+HTTP connections indefinitely.
+
+Fixes #99999
+```
+
+Code changes that do not touch any Go source files should follow the below guidelines. These
+code changes fall into two different categories "chores" and "real code". Chores are changes
+to files like the Makefile, .travis.yml, or any markdown file documentation updates. Real code
+changes are things like updating template processor images, but do not include any Go source file
+changes.
+
+Example "real code" changes commit message.
+```
+template/jinja: pin jinja version in template processor image
+
+This change pins the jinja python module version in the jinja template
+processor image to esnure a consitent version of jinja is installed. Prior
+to this change the latest version of the jinja pip module would always be
+install which could lead to surprise breakages everytime new template
+processor images were built.
+
+Fixes #99999
+```
+
+Example "chore" commit message.
+```
+chore: fail CI tests when golint errors are found
+
+Adding the -set_exit_status CLI option to the golint command ensures that
+the CI tests will fail when golint errors are found. Prior to this change
+Travis CI builds would succeed when golint errors were found.
+
+Fixes #99999
 ```

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,11 +1,14 @@
-<!-- Please fill in each section below to help us better prioritize your pull request. Thanks! -->
+<!--
+    Please read https://github.com/KohlsTechnology/eunomia/blob/master/.github/CONTRIBUTING.md before submitting
+    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
+-->
 
 **Description**
 
 <!-- Please provide a summary of the change here. -->
 
 <!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
-Fixes #(issue)
+Fixes #ISSUE
 
 **Type of change**
 


### PR DESCRIPTION
**Description**

The commit message standards have been updated in the CONTRIBUTING.md
file to try and help improve this projects git commit messages. Additionally
the PR template now has a link to the CONTRIBUTING.md file to help
contributors learn about our commit message standards prior to
submitting their pull request.

This pull request is not related to an open issue.

**Type of change**

* Bug fix (non-breaking change which fixes an issue)
* This change requires a documentation update
