### PR TITLE
Allow eunomia to schedule on any node in the cluster

### DIFF
--- a/deploy/helm/eunomia-operator/templates/namespace.yaml
+++ b/deploy/helm/eunomia-operator/templates/namespace.yaml
@@ -2,6 +2,8 @@
 apiVersion: v1
 kind: Namespace
 metadata:
+  annotations:
+    openshift.io/node-selector: ''
   name: {{ .namespace }}
 spec:
 {{- end }}


### PR DESCRIPTION
**Description**
Add capability to allow eunomia-operator to schedule on any node in the cluster , By adding annotation `openshift.io/node-selector` with empty value . 


Fixes #99 

**Type of change**

* New feature (non-breaking change which adds functionality)
