### PR TITLE
Set Docker context to be operator-sdk compliant

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -17,6 +17,6 @@ FROM registry.access.redhat.com/ubi8/ubi:latest
 ENV OPERATOR=/usr/local/bin/eunomia-operator
 
 # install operator binary
-COPY _output/bin/eunomia ${OPERATOR}
+COPY build/_output/bin/eunomia ${OPERATOR}
 
 ENTRYPOINT ["/usr/local/bin/entrypoint"]

--- a/scripts/build-images.sh
+++ b/scripts/build-images.sh
@@ -31,6 +31,7 @@ PUSH_IMAGES=${2:+true}
 build_image() {
   local context_dir=$1
   local image_url=${REPOSITORY}/$2
+  local dockerfile_path=${3:-"${context_dir}/Dockerfile"}
   local push=${PUSH_IMAGES:-false}
 
   if [ -f "${context_dir}/Dockerfile.in" ]; then
@@ -41,7 +42,7 @@ build_image() {
   fi
 
   # Make sure "dev" docker tag always points to the most recently changed commit
-  docker build "${context_dir}" -t "${image_url}:dev"
+  docker build "${context_dir}" -t "${image_url}:dev" -f "${dockerfile_path}"
   if $push; then
       docker push "${image_url}:dev"
   fi
@@ -66,7 +67,7 @@ build_image() {
 }
 
 # building and pushing the operator images
-build_image build/ eunomia-operator
+build_image . eunomia-operator build/Dockerfile
 
 # building and pushing base template processor images
 build_image template-processors/base/ eunomia-base


### PR DESCRIPTION
<!--
    Please read https://github.com/KohlsTechnology/eunomia/blob/master/.github/CONTRIBUTING.md before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->
Set Docker context in building eunomia-operator image to eunomia project
root directory, and pass Dockerfile location explicitly with the -f flag.

Docker context in eunomia-operator was set to eunomia/build which was
causing "operator-sdk build" command to not work.

Now, with the context set properly, eunomia-operator Docker image can be
built either with the make utility, or "operator-sdk build" command.

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #174 

**Type of change**

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)