### PR TITLE
scripts: fix e2e-test.sh to work on non-Travis

### DIFF
--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -27,7 +27,7 @@ export GO111MODULE=on
 
 # If we're called as part of CI build on a PR, make sure we test the resources
 # (templates etc.) from the PR, instead of the master branch of the main repo
-if [ "${TRAVIS_PULL_REQUEST_BRANCH}" ]; then
+if [ "${TRAVIS_PULL_REQUEST_BRANCH:-}" ]; then
   export EUNOMIA_URI="https://github.com/${TRAVIS_PULL_REQUEST_SLUG}"
   export EUNOMIA_REF="${TRAVIS_PULL_REQUEST_BRANCH}"
 fi


### PR DESCRIPTION


<!--
    Please read https://github.com/KohlsTechnology/eunomia/blob/master/.github/CONTRIBUTING.md before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->
The TRAVIS_PULL_REQUEST_BRANCH env variable is not defined when running
the script locally, so we need to make sure the `set -u` check doesn't
trigger a failure of the script.

**Type of change**

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)
