### PR TITLE
gitClone.sh: fix copying .git* files to home dir

### DIFF
--- a/template-processors/base/bin/gitClone.sh
+++ b/template-processors/base/bin/gitClone.sh
@@ -28,12 +28,7 @@ function pullFromTemplatesRepo {
     local no_proxy="$TEMPLATE_GIT_NO_PROXY"
   fi
   if [ "$TEMPLATE_GITCONFIG" ] && [ -d "$TEMPLATE_GITCONFIG" ]; then
-    for file in "$TEMPLATE_GITCONFIG"/*; do
-      cp -f "$file" "~/$(basename $file)"
-    done
-    for file in "$TEMPLATE_GITCONFIG"/.git*; do
-      cp -f "$file" "~/$(basename $file)"
-    done
+    cp -r "${TEMPLATE_GITCONFIG}/." "${HOME}/"
   else
     export GIT_SSL_NO_VERIFY=true
   fi
@@ -59,12 +54,7 @@ function pullFromParametersRepo {
     local no_proxy="$PARAMETER_GIT_NO_PROXY"
   fi
   if [ "$PARAMETER_GITCONFIG" ] && [ -d "$PARAMETER_GITCONFIG" ]; then
-    for file in "$PARAMETER_GITCONFIG"/*; do
-      cp -f "$file" "~/$(basename $file)"
-    done
-    for file in "$PARAMETER_GITCONFIG"/.git*; do
-      cp -f "$file" "~/$(basename $file)"
-    done
+    cp -r "${PARAMETER_GITCONFIG}/." "${HOME}/"
   else
     export GIT_SSL_NO_VERIFY=true
   fi


### PR DESCRIPTION
Replaced the 'for' loops with a recursive copy of entire dir since '*' doesn't copy hidden files.
Replaced '~/' with '$HOME' as tilde is not expanded when in quotes.

Fixes #173 #130

<!--
    Please read https://github.com/KohlsTechnology/eunomia/blob/master/.github/CONTRIBUTING.md before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**
I build my own template-processor image with this fix on top of eunomia-jinja:v0.0.4 image and it worked fine on my GKE cluster. 

Fixes #173 #130 

**Type of change**
* Bug fix (non-breaking change which fixes an issue)