### PR TITLE
template/base: allow hierarchy to include empty directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## v0.0.6 (Unreleased)
+BUG FIXES:
+* Allow empty hierarchy directories [GH-184](https://github.com/KohlsTechnology/eunomia/pull/184)
 
 ## v0.0.5 (December 5, 2019)
 BUG FIXES:

--- a/template-processors/base/bin/processParameters.sh
+++ b/template-processors/base/bin/processParameters.sh
@@ -51,7 +51,9 @@ if [ -n "${FOLDERS}" ]; then
     YAML_FILES="$(find "${DIR}" -maxdepth 1 -name \*.json -o -name \*.yaml -o -name \*.yml)"
 
     # merge the files
-    goyq merge -i -x "${VALUES_FILE}" ${YAML_FILES}
+    if [ ! -z "${YAML_FILES}" ]; then
+      goyq merge -i -x "${VALUES_FILE}" ${YAML_FILES}
+    fi
   done
 else
   echo "ERROR - no folders found for processing"

--- a/template-processors/base/bin/processParameters.sh
+++ b/template-processors/base/bin/processParameters.sh
@@ -48,7 +48,7 @@ if [ -n "${FOLDERS}" ]; then
     echo "Processing files in ${DIR}"
 
     # get the list of yaml files to process
-    YAML_FILES="$(find "${DIR}" -name \*.json -o -name \*.yaml -o -name \*.yml  -maxdepth 1)"
+    YAML_FILES="$(find "${DIR}" -maxdepth 1 -name \*.json -o -name \*.yaml -o -name \*.yml)"
 
     # merge the files
     goyq merge -i -x "${VALUES_FILE}" ${YAML_FILES}

--- a/test/e2e/testdata/hierarchy/level4/hierarchy.lst
+++ b/test/e2e/testdata/hierarchy/level4/hierarchy.lst
@@ -1,4 +1,5 @@
 ../level1
 ../level2
 ../level3-empty
+../level5-no-files
 ./


### PR DESCRIPTION
<!--
    Please read https://github.com/KohlsTechnology/eunomia/blob/master/.github/CONTRIBUTING.md before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->
Allow the hierarchy resolution in the base processParameters.sh script to include directories that do not include any yaml or json files.

In addition, while testing I noticed warnings being logged by the find command due to ordering of options. I have moved the `-name` flags to the end to address this.

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #184 

**Type of change**

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)
