### PR TITLE
template-processors/base/bin: limit label length (#202)

### DIFF
--- a/template-processors/base/bin/resourceManager.sh
+++ b/template-processors/base/bin/resourceManager.sh
@@ -80,9 +80,11 @@ function deleteByOldLabels {
 
 function createUpdateResources {
   # NOTE: Kubernetes currently requires that first *and last* character of
-  # label values are alphanumerical - we're adding the ".owned" suffix to
-  # ensure that.
-  local owner="ns-$NAMESPACE.gitopsconfig-$GITOPSCONFIG_NAME.owned"
+  # label values are alphanumerical - we're adding the "own" prefix & suffix to
+  # ensure that. Also, Kubernetes requires it to be <=63 chars long, so we're
+  # taking a MD5 hash of actual name (MD5 hash is 33 chars long).
+  # See: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set
+  local owner="own.$( echo "$NAMESPACE $GITOPSCONFIG_NAME" | md5sum | awk '{print$1}' ).own"
   local timestamp="$(date +%s)"
   case "$CREATE_MODE" in
     CreateOrMerge)

--- a/template-processors/base/bin/resourceManager.sh
+++ b/template-processors/base/bin/resourceManager.sh
@@ -64,7 +64,8 @@ function addLabels {
 function deleteByOldLabels {
   local owner="$1"
   local timestamp="$2"
-  local allKinds="$(kube api-resources --verbs=list -o name | paste -sd, -)"
+  # NOTE: removing componentstatus because it shows up unintended in ownedKinds: https://github.com/kubernetes/kubectl/issues/151#issuecomment-562578617
+  local allKinds="$(kube api-resources --verbs=list -o name  | egrep -iv '^componentstatus(es)?$' | paste -sd, -)"
   local ownedKinds="$(kube get "$allKinds" --ignore-not-found \
       -l "$TAG_OWNER==$owner" \
       -o custom-columns=kind:.kind \


### PR DESCRIPTION
<!--
    Please read https://github.com/KohlsTechnology/eunomia/blob/master/.github/CONTRIBUTING.md before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->

When calculating label values for automatic deletion (#24), use MD5 hash instead of full namespace+name, to fit in the length limit allowed for kubernetes label values. See more details in the commit messsage.

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #202 

**Type of change**

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)

**Checklist**
- [ ] Unit tests and e2e tests updated
  - there are currently no unit/e2e tests for the examples, and adding them is currently not deemed in scope of this fix
- [ ] Documentation updated
  - not needed, this is a bugfix
