### PR TITLE
fixes #226, change the quotes to " so that the ssh command does not fail

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ For certificate based authentication, create the following `.gitconfig`:
 
 ```ini
 [core]
-    sshCommand = 'ssh -i /template-gitconfig/mykey.rsa -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no'
+    sshCommand = "ssh -i /template-gitconfig/mykey.rsa -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no"
 ```
 
 and add the `mykey.rsa` file to the secret.


### PR DESCRIPTION
<!--
    Please read https://github.com/KohlsTechnology/eunomia/blob/master/.github/CONTRIBUTING.md before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->
Fix typo in the readme for using ssh git keys

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #226 

**Type of change**

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)

**Checklist**

- [ ] Unit tests and e2e tests updated
- [x] Documentation updated
