### PR TITLE
Include template-processors images in the testing phase in DEVELOPMENT.md

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -74,7 +74,7 @@ From here you can build the eunomia-operator Docker image and manually push it t
 
 ### Building the image and pushing to a remote registry
 
-Run the following to build and push the images:
+Run the following to build and push the eunomia-operator image as well as template-processors images:
 
 ```shell
 export REGISTRY=<your registry>
@@ -92,12 +92,11 @@ If you want to play with eunomia deployed to Minikube or Minishift, here are som
 # Start minikube
 minikube start
 
-# Set env variables for docker CLI to use minikube's docker daemon
-eval $(minikube docker-env)
-
-# Build your eunomia-operator image and store it in minikube's docker registry
+# Build your eunomia-operator binary
 GOOS=linux make
-docker build build/ --tag quay.io/kohlstechnology/eunomia-operator:dev
+
+# Build eunomia-operator and template-processors images and store them in minikube's docker registry
+scripts/deploy-to-local.sh minikube
 
 # Deploy the operator, use your locally-built image
 helm template deploy/helm/eunomia-operator/ \
@@ -111,15 +110,14 @@ helm template deploy/helm/eunomia-operator/ \
 # Start minishift
 minishift start --vm-driver virtualbox
 
-# Set env variables for docker CLI to use minishift's docker daemon
-eval $(minishift docker-env)
-
-# Build eunomia-operator image and store it in minishift's docker registry
+# Build your eunomia-operator binary
 GOOS=linux make
-docker build build/ --tag quay.io/kohlstechnology/eunomia-operator:dev
 
 # Log in to minishift as admin
 oc login -u system:admin
+
+# Build eunomia-operator and template-processors images and store them in minishift's docker registry
+scripts/deploy-to-local.sh minishift
 
 # Deploy the operator, use your locally-built image
 helm template deploy/helm/eunomia-operator/ \

--- a/scripts/build-images.sh
+++ b/scripts/build-images.sh
@@ -17,7 +17,7 @@
 set -euxo pipefail
 
 REPOSITORY=${1}
-if [ -z "${TRAVIS_TAG}" ] ; then
+if [ -z "${TRAVIS_TAG:-}" ] ; then
     IMAGE_TAG="dev"
 else
     IMAGE_TAG=${TRAVIS_TAG}

--- a/scripts/deploy-to-local.sh
+++ b/scripts/deploy-to-local.sh
@@ -16,8 +16,28 @@
 
 set -euxo pipefail
 
-#This scripts helps with deploying images locally to minikube docker registry.
+# This scripts helps with deploying images locally to minikube or minishift docker registry.
+usage() {
+    cat <<EOT
+deploy-to-local.sh minikube|minishift
 
-eval $(minikube docker-env)
-export TRAVIS_TAG=latest
+Build template-processors and eunomia-operator images and deploy them to
+a local minikube or minishift docker registry.
+EOT
+}
+
+if [[ ! "${1:-}" ]]; then
+    usage
+    exit 1
+fi
+
+if [[ "$1" == minikube ]]; then
+    eval $(minikube docker-env)
+elif [[ "$1" == minishift ]]; then
+    eval $(minishift docker-env)
+else
+    usage
+    exit 1
+fi
+
 "$(dirname "$0")/build-images.sh" quay.io/kohlstechnology


### PR DESCRIPTION
<!--
    Please read https://github.com/KohlsTechnology/eunomia/blob/master/.github/CONTRIBUTING.md before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->
Include building and deployment of templates-processors images in the
testing phase. Do it this way because a template-processor image is
tightly tied with eunomia-operator and there is little sense in testing
one without the other.

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Doesn't fix any issue - this PR addresses the discussion from https://github.com/KohlsTechnology/eunomia/pull/200#discussion_r355974244 

**Type of change**

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)

**Checklist**

- [ ] Unit tests and e2e tests updated
- [x] Documentation updated
