### PR TITLE
add proper error check for jobs not found

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/go-logr/zapr v0.1.0 // indirect
 	github.com/go-openapi/spec v0.18.0
 	github.com/golang/groupcache v0.0.0-20180924190550-6f2cf27854a4 // indirect
+	github.com/golang/mock v1.2.0 // indirect
 	github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c // indirect
 	github.com/google/go-github v17.0.0+incompatible
 	github.com/google/go-querystring v1.0.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,6 @@ require (
 	github.com/go-logr/zapr v0.1.0 // indirect
 	github.com/go-openapi/spec v0.18.0
 	github.com/golang/groupcache v0.0.0-20180924190550-6f2cf27854a4 // indirect
-	github.com/golang/mock v1.2.0 // indirect
 	github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c // indirect
 	github.com/google/go-github v17.0.0+incompatible
 	github.com/google/go-querystring v1.0.0 // indirect

--- a/pkg/controller/gitopsconfig/jobmonitor.go
+++ b/pkg/controller/gitopsconfig/jobmonitor.go
@@ -24,6 +24,7 @@ import (
 	"gopkg.in/robfig/cron.v2"
 	batchv1 "k8s.io/api/batch/v1"
 	batchv1beta1 "k8s.io/api/batch/v1beta1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -159,8 +160,7 @@ func (job *jobmonitor) watchjob(instanceName, instanceNamespace string) {
 		time.Sleep(10 * time.Second)
 		jobState, err := job.checkResult()
 		if err != nil {
-			// FIXME: change below error message detection to something more robust, string matching is super flaky
-			if err.Error() == `Job.batch "`+instanceName+`" not found` {
+			if errors.IsNotFound(err) {
 				log.Info("The job has been deleted")
 				break
 			}


### PR DESCRIPTION
**Description**
Cronjobs that were deleted are now properly detected and Eunomia does not end up in an endless loop.

Fixes #241 

Replace the unreliable string comparison for "not found" error checks, with the proper k8s function.

```
{"level":"info","ts":1578841086.369399,"logger":"gitopsconfig-controller","msg":"retrying the GetJob for CheckResult"}
{"level":"info","ts":1578841086.369462,"logger":"gitopsconfig-controller","msg":"Retry of GetJob for CheckResult unsuccessful: Job.batch \"gitopsconfig-hello-world-helm-cfsv6c\" not found"}
{"level":"info","ts":1578841086.369468,"logger":"gitopsconfig-controller","msg":"The job has been deleted"}
```

**Type of change**
* Bug fix (non-breaking change which fixes an issue)

**Checklist**

- [ ] Unit tests and e2e tests updated
- [ ] Documentation updated
