### PR TITLE
test/e2e: fix intermittent resourceVersion error in modes_test.go

### DIFF
--- a/test/e2e/issue24_test.go
+++ b/test/e2e/issue24_test.go
@@ -26,6 +26,7 @@ import (
 	framework "github.com/operator-framework/operator-sdk/pkg/test"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
 
 	"github.com/KohlsTechnology/eunomia/pkg/apis"
 	gitopsv1alpha1 "github.com/KohlsTechnology/eunomia/pkg/apis/eunomia/v1alpha1"
@@ -104,15 +105,19 @@ func TestIssue24_RemovedResourceGetsDeleted(t *testing.T) {
 
 	// Step 2: change the CR to one with missing 'now-only' resource, then check that the pod gets deleted
 
-	err = framework.Global.Client.Get(context.TODO(), types.NamespacedName{Namespace: namespace, Name: gitops.ObjectMeta.Name}, gitops)
+	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		err := framework.Global.Client.Get(context.TODO(), types.NamespacedName{Namespace: namespace, Name: gitops.ObjectMeta.Name}, gitops)
+		if err != nil {
+			t.Fatal(err)
+		}
+		gitops.Spec.TemplateSource.ContextDir = "test/e2e/testdata/issue24/template2"
+		err = framework.Global.Client.Update(context.Background(), gitops)
+		return err
+	})
 	if err != nil {
 		t.Fatal(err)
 	}
-	gitops.Spec.TemplateSource.ContextDir = "test/e2e/testdata/issue24/template2"
-	err = framework.Global.Client.Update(context.Background(), gitops)
-	if err != nil {
-		t.Fatal(err)
-	}
+
 	// Verify that the main "hello-world-issue24" app gets upgraded
 	err = WaitForPodWithImage(t, framework.Global, namespace, "hello-world-issue24", "hello-app:2.0", retryInterval, timeout)
 	if err != nil {

--- a/test/e2e/modes_test.go
+++ b/test/e2e/modes_test.go
@@ -26,6 +26,7 @@ import (
 	framework "github.com/operator-framework/operator-sdk/pkg/test"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
 
 	"github.com/KohlsTechnology/eunomia/pkg/apis"
 	gitopsv1alpha1 "github.com/KohlsTechnology/eunomia/pkg/apis/eunomia/v1alpha1"
@@ -100,13 +101,16 @@ func TestModes_CreateReplaceDelete(t *testing.T) {
 
 	// Step 2: change the CR to a different version of image, using "Replace" mode, then verify pod change
 
-	err = framework.Global.Client.Get(context.TODO(), types.NamespacedName{Namespace: namespace, Name: gitops.ObjectMeta.Name}, gitops)
-	if err != nil {
-		t.Fatal(err)
-	}
-	gitops.Spec.TemplateSource.ContextDir = "test/e2e/testdata/modes/template2"
-	gitops.Spec.ResourceHandlingMode = "Replace"
-	err = framework.Global.Client.Update(context.Background(), gitops)
+	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		err := framework.Global.Client.Get(context.TODO(), types.NamespacedName{Namespace: namespace, Name: gitops.ObjectMeta.Name}, gitops)
+		if err != nil {
+			t.Fatal(err)
+		}
+		gitops.Spec.TemplateSource.ContextDir = "test/e2e/testdata/modes/template2"
+		gitops.Spec.ResourceHandlingMode = "Replace"
+		err = framework.Global.Client.Update(context.Background(), gitops)
+		return err
+	})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -118,12 +122,15 @@ func TestModes_CreateReplaceDelete(t *testing.T) {
 
 	// Step 2: change the CR to "Delete" mode, then verify that the Pod is deleted
 
-	err = framework.Global.Client.Get(context.TODO(), types.NamespacedName{Namespace: namespace, Name: gitops.ObjectMeta.Name}, gitops)
-	if err != nil {
-		t.Fatal(err)
-	}
-	gitops.Spec.ResourceHandlingMode = "Delete"
-	err = framework.Global.Client.Update(context.Background(), gitops)
+	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		err := framework.Global.Client.Get(context.TODO(), types.NamespacedName{Namespace: namespace, Name: gitops.ObjectMeta.Name}, gitops)
+		if err != nil {
+			t.Fatal(err)
+		}
+		gitops.Spec.ResourceHandlingMode = "Delete"
+		err = framework.Global.Client.Update(context.Background(), gitops)
+		return err
+	})
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION


<!--
    Please read https://github.com/KohlsTechnology/eunomia/blob/master/.github/CONTRIBUTING.md before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->
The following error is sometimes breaking TestModes_CreateReplaceDelete:

    modes_test.go:111: Operation cannot be fulfilled on gitopsconfigs.eunomia.kohls.io "gitops-modes": the object has been modified; please apply your changes to the latest version and try again

(see e.g.: https://travis-ci.com/KohlsTechnology/eunomia/builds/144162028#L2111)

This commit adds a retry on the block of the code trying to update the
resource, as suggested on StackOverflow:
https://stackoverflow.com/q/56919318

**Type of change**

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)

**Checklist**

- [x] Unit tests and e2e tests updated (the fix is specifically to a test)
- [ ] Documentation updated (n/a)
