### PR TITLE
Use golang.org/x/xerrors instead of raw `return err`

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -28,7 +28,7 @@ var AddToManagerFuncs []func(manager.Manager) error
 func AddToManager(m manager.Manager) error {
 	for _, f := range AddToManagerFuncs {
 		if err := f(m); err != nil {
-			return xerrors.Errorf("cannot add controllers to the manager %q: %w", m, err)
+			return xerrors.Errorf("cannot add controllers to the manager: %w", err)
 		}
 	}
 	return nil

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -17,6 +17,7 @@ limitations under the License.
 package controller
 
 import (
+	"golang.org/x/xerrors"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
@@ -27,7 +28,7 @@ var AddToManagerFuncs []func(manager.Manager) error
 func AddToManager(m manager.Manager) error {
 	for _, f := range AddToManagerFuncs {
 		if err := f(m); err != nil {
-			return err
+			return xerrors.Errorf("cannot add controllers to the manager %q: %w", m, err)
 		}
 	}
 	return nil

--- a/pkg/controller/gitopsconfig/controller.go
+++ b/pkg/controller/gitopsconfig/controller.go
@@ -402,8 +402,8 @@ func (r *Reconciler) manageDeletion(instance *gitopsv1alpha1.GitOpsConfig) (reco
 		LabelSelector: selector,
 	}, jobList)
 	if err != nil {
-		log.Error(err, "unable to list all delete jobs")
-		return reconcile.Result{}, xerrors.Errorf("unable to list all delete jobs: %w", err)
+		log.Error(err, "unable to list all delete jobs", "namespace", instance.GetNamespace())
+		return reconcile.Result{}, xerrors.Errorf("unable to list all delete jobs in namespace %q: %w", instance.GetNamespace(), err)
 	}
 	applicableJobList := []batchv1.Job{}
 	//filtering by those that are might have been created by this gitopsconfig

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -18,13 +18,13 @@ package util
 
 import (
 	"bytes"
-	"golang.org/x/xerrors"
 	"io/ioutil"
 	"text/template"
 
 	"github.com/KohlsTechnology/eunomia/pkg/apis/eunomia/v1alpha1"
 	"github.com/dchest/uniuri"
 	"github.com/ghodss/yaml"
+	"golang.org/x/xerrors"
 	batch "k8s.io/api/batch/v1"
 	batchv1beta1 "k8s.io/api/batch/v1beta1"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
@@ -58,7 +58,7 @@ func InitializeTemplates(jobTemplateFileName string, cronJobTemplateFileName str
 	jobTemplate, err = jobTemplate.Parse(string(text))
 	if err != nil {
 		log.Error(err, "error parsing template", "template", text)
-		return xerrors.Errorf("error parsing template %q: %w", text, err)
+		return xerrors.Errorf("error parsing template: %w", err)
 	}
 
 	text, err = ioutil.ReadFile(cronJobTemplateFileName)
@@ -96,8 +96,8 @@ func CreateJob(jobmergedata JobMergeData) (batch.Job, error) {
 	}
 	err = yaml.Unmarshal(b.Bytes(), &job)
 	if err != nil {
-		log.Error(err, "error unmashalling the job manifest", "manifest", string(b.Bytes()))
-		return job, xerrors.Errorf("error unmashalling the job manifest %q: %w", string(b.Bytes()), err)
+		log.Error(err, "error unmarshalling the job manifest", "manifest", string(b.Bytes()))
+		return job, xerrors.Errorf("error unmarshalling the job manifest: %w", err)
 	}
 	return job, nil
 }
@@ -113,8 +113,8 @@ func CreateCronJob(jobmergedata JobMergeData) (batchv1beta1.CronJob, error) {
 	}
 	err = yaml.Unmarshal(b.Bytes(), &cronjob)
 	if err != nil {
-		log.Error(err, "error unmashalling the job manifest", "manifest", string(b.Bytes()))
-		return cronjob, xerrors.Errorf("error unmashalling the job manifest %q: %w", string(b.Bytes()), err)
+		log.Error(err, "error unmarshalling the job manifest", "manifest", string(b.Bytes()))
+		return cronjob, xerrors.Errorf("error unmarshalling the job manifest: %w", err)
 	}
 	return cronjob, nil
 }

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -63,8 +63,8 @@ func InitializeTemplates(jobTemplateFileName string, cronJobTemplateFileName str
 
 	text, err = ioutil.ReadFile(cronJobTemplateFileName)
 	if err != nil {
-		log.Error(err, "error reading job template file", "filename", cronJobTemplateFileName)
-		return xerrors.Errorf("error reading job template file %q: %w", cronJobTemplateFileName, err)
+		log.Error(err, "error reading cron job template file", "filename", cronJobTemplateFileName)
+		return xerrors.Errorf("error reading cron job template file %q: %w", cronJobTemplateFileName, err)
 	}
 	cronJobTemplate = template.New("Job").Funcs(template.FuncMap{
 		"getCron": func(config v1alpha1.GitOpsConfig) string {
@@ -79,8 +79,8 @@ func InitializeTemplates(jobTemplateFileName string, cronJobTemplateFileName str
 
 	cronJobTemplate, err = cronJobTemplate.Parse(string(text))
 	if err != nil {
-		log.Error(err, "error parsing template", "template", text)
-		return xerrors.Errorf("error parsing template %q: %w", text, err)
+		log.Error(err, "error parsing cron job template", "template", text)
+		return xerrors.Errorf("error parsing cron job template: %w", err)
 	}
 	return nil
 }
@@ -91,13 +91,13 @@ func CreateJob(jobmergedata JobMergeData) (batch.Job, error) {
 	var b bytes.Buffer
 	err := jobTemplate.Execute(&b, &jobmergedata)
 	if err != nil {
-		log.Error(err, "error executing template")
-		return job, xerrors.Errorf("error executing template: %w", err)
+		log.Error(err, "error executing job template from a template merge data")
+		return job, xerrors.Errorf("error executing job template from a template merge data: %w", err)
 	}
 	err = yaml.Unmarshal(b.Bytes(), &job)
 	if err != nil {
-		log.Error(err, "error unmarshalling the job manifest", "manifest", string(b.Bytes()))
-		return job, xerrors.Errorf("error unmarshalling the job manifest: %w", err)
+		log.Error(err, "error unmarshalling a job manifest", "manifest", string(b.Bytes()))
+		return job, xerrors.Errorf("error unmarshalling a job manifest: %w", err)
 	}
 	return job, nil
 }
@@ -108,13 +108,13 @@ func CreateCronJob(jobmergedata JobMergeData) (batchv1beta1.CronJob, error) {
 	var b bytes.Buffer
 	err := cronJobTemplate.Execute(&b, &jobmergedata)
 	if err != nil {
-		log.Error(err, "error executing template")
-		return cronjob, xerrors.Errorf("error executing template: %w", err)
+		log.Error(err, "error executing cron job template from a template merge data")
+		return cronjob, xerrors.Errorf("error executing cron job template from a template merge data: %w", err)
 	}
 	err = yaml.Unmarshal(b.Bytes(), &cronjob)
 	if err != nil {
-		log.Error(err, "error unmarshalling the job manifest", "manifest", string(b.Bytes()))
-		return cronjob, xerrors.Errorf("error unmarshalling the job manifest: %w", err)
+		log.Error(err, "error unmarshalling a cron job manifest", "manifest", string(b.Bytes()))
+		return cronjob, xerrors.Errorf("error unmarshalling a cron job manifest: %w", err)
 	}
 	return cronjob, nil
 }

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -18,6 +18,7 @@ package util
 
 import (
 	"bytes"
+	"golang.org/x/xerrors"
 	"io/ioutil"
 	"text/template"
 
@@ -45,8 +46,8 @@ type JobMergeData struct {
 func InitializeTemplates(jobTemplateFileName string, cronJobTemplateFileName string) error {
 	text, err := ioutil.ReadFile(jobTemplateFileName)
 	if err != nil {
-		log.Error(err, "Error reading job template file", "filename", jobTemplateFileName)
-		return err
+		log.Error(err, "error reading job template file", "filename", jobTemplateFileName)
+		return xerrors.Errorf("error reading job template file %q: %w", jobTemplateFileName, err)
 	}
 	jobTemplate = template.New("Job").Funcs(template.FuncMap{
 		"getID": func() string {
@@ -56,14 +57,14 @@ func InitializeTemplates(jobTemplateFileName string, cronJobTemplateFileName str
 
 	jobTemplate, err = jobTemplate.Parse(string(text))
 	if err != nil {
-		log.Error(err, "Error parsing template", "template", text)
-		return err
+		log.Error(err, "error parsing template", "template", text)
+		return xerrors.Errorf("error parsing template %q: %w", text, err)
 	}
 
 	text, err = ioutil.ReadFile(cronJobTemplateFileName)
 	if err != nil {
-		log.Error(err, "Error reading job template file", "filename", cronJobTemplateFileName)
-		return err
+		log.Error(err, "error reading job template file", "filename", cronJobTemplateFileName)
+		return xerrors.Errorf("error reading job template file %q: %w", cronJobTemplateFileName, err)
 	}
 	cronJobTemplate = template.New("Job").Funcs(template.FuncMap{
 		"getCron": func(config v1alpha1.GitOpsConfig) string {
@@ -78,8 +79,8 @@ func InitializeTemplates(jobTemplateFileName string, cronJobTemplateFileName str
 
 	cronJobTemplate, err = cronJobTemplate.Parse(string(text))
 	if err != nil {
-		log.Error(err, "Error parsing template", "template", text)
-		return err
+		log.Error(err, "error parsing template", "template", text)
+		return xerrors.Errorf("error parsing template %q: %w", text, err)
 	}
 	return nil
 }
@@ -90,15 +91,15 @@ func CreateJob(jobmergedata JobMergeData) (batch.Job, error) {
 	var b bytes.Buffer
 	err := jobTemplate.Execute(&b, &jobmergedata)
 	if err != nil {
-		log.Error(err, "Error executing template")
-		return job, err
+		log.Error(err, "error executing template")
+		return job, xerrors.Errorf("error executing template: %w", err)
 	}
 	err = yaml.Unmarshal(b.Bytes(), &job)
 	if err != nil {
-		log.Error(err, "Error unmashalling the job manifest", "manifest", string(b.Bytes()))
-		return job, err
+		log.Error(err, "error unmashalling the job manifest", "manifest", string(b.Bytes()))
+		return job, xerrors.Errorf("error unmashalling the job manifest %q: %w", string(b.Bytes()), err)
 	}
-	return job, err
+	return job, nil
 }
 
 // CreateCronJob returns a Job type from a template merge data
@@ -107,13 +108,13 @@ func CreateCronJob(jobmergedata JobMergeData) (batchv1beta1.CronJob, error) {
 	var b bytes.Buffer
 	err := cronJobTemplate.Execute(&b, &jobmergedata)
 	if err != nil {
-		log.Error(err, "Error executing template")
-		return cronjob, err
+		log.Error(err, "error executing template")
+		return cronjob, xerrors.Errorf("error executing template: %w", err)
 	}
 	err = yaml.Unmarshal(b.Bytes(), &cronjob)
 	if err != nil {
-		log.Error(err, "Error unmashalling the job manifest", "manifest", string(b.Bytes()))
-		return cronjob, err
+		log.Error(err, "error unmashalling the job manifest", "manifest", string(b.Bytes()))
+		return cronjob, xerrors.Errorf("error unmashalling the job manifest %q: %w", string(b.Bytes()), err)
 	}
-	return cronjob, err
+	return cronjob, nil
 }

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -23,13 +23,13 @@ import (
 	goctx "context"
 	"encoding/json"
 	"fmt"
-	"golang.org/x/xerrors"
 	"io"
 	"strings"
 	"testing"
 	"time"
 
 	framework "github.com/operator-framework/operator-sdk/pkg/test"
+	"golang.org/x/xerrors"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -69,7 +69,7 @@ func WaitForPod(t *testing.T, f *framework.Framework, namespace, name string, re
 			t.Logf("Waiting for availability of %s pod", name)
 			return false, nil
 		case err != nil:
-			return false, xerrors.Errorf("cannot read kubernetes object: %w", err)
+			return false, xerrors.Errorf("client failed to retrieve pod %q in namespace %q: %w", name, namespace, err)
 		case pod.Status.Phase == "Running":
 			return true, nil
 		default:
@@ -94,7 +94,7 @@ func WaitForPodWithImage(t *testing.T, f *framework.Framework, namespace, name, 
 			t.Logf("Waiting for availability of %s pod", name)
 			return false, nil
 		case err != nil:
-			return false, xerrors.Errorf("cannot read kubernetes object: %w", err)
+			return false, xerrors.Errorf("client failed to retrieve pod %q with image %q in namespace %q: %w", name, image, namespace, err)
 		case pod != nil && pod.Status.Phase == "Running":
 			return true, nil
 		default:
@@ -128,7 +128,7 @@ func WaitForPodAbsence(t *testing.T, f *framework.Framework, namespace, name, im
 		case apierrors.IsNotFound(err):
 			return true, nil
 		case err != nil:
-			return false, xerrors.Errorf("cannot read kubernetes object: %w", err)
+			return false, xerrors.Errorf("client failed to retrieve pod %q with image %q in namespace %q: %w", name, image, namespace, err)
 		case pod == nil || pod.Status.Phase == "Terminated":
 			return true, nil
 		default:


### PR DESCRIPTION
**Description**

Use golang.org/x/errors so errors have a better context for
easier troubleshooting.

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #178 

**Type of change**

<!-- Please delete options that are not relevant. -->

* New feature (non-breaking change which adds functionality)

**Checklist**

- [not needed] Unit tests and e2e tests updated
- [not needed] Documentation updated
