### PR TITLE
Set eunomia-operator user to non-root

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -22,4 +22,8 @@ COPY job-templates/* /default-job-templates/
 # install operator binary
 COPY _output/bin/eunomia ${OPERATOR}
 
+RUN groupadd -r eunomia && useradd --no-log-init -r -g eunomia eunomia
+
+USER eunomia
+
 ENTRYPOINT ["/usr/local/bin/eunomia-operator"]


### PR DESCRIPTION
**Description**

In order to follow the "least privilege" security best practice,
set eunomia-operator user to non-root.

Fixes #171 

**Type of change**

* New feature (non-breaking change which adds functionality)

**Checklist**

- [not needed] Unit tests and e2e tests updated
- [not needed] Documentation updated
