### PR TITLE
Run each e2e test function in a separate namespace

### DIFF
--- a/deploy/helm/eunomia-operator/templates/clusterrole-gitopsconfig-admin.yaml
+++ b/deploy/helm/eunomia-operator/templates/clusterrole-gitopsconfig-admin.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.eunomia.operator.deployment.nsRbacOnly -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -13,3 +14,4 @@ rules:
   - 'gitopsconfigs'
   verbs:
   - '*'
+{{- end }}

--- a/deploy/helm/eunomia-operator/templates/clusterrole-gitopsconfig-viewer.yaml
+++ b/deploy/helm/eunomia-operator/templates/clusterrole-gitopsconfig-viewer.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.eunomia.operator.deployment.nsRbacOnly -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -16,3 +17,4 @@ rules:
   - get
   - list
   - watch
+{{- end }}

--- a/deploy/helm/eunomia-operator/templates/clusterrole-operators.yaml
+++ b/deploy/helm/eunomia-operator/templates/clusterrole-operators.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.eunomia.operator.deployment.nsRbacOnly -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -34,3 +35,4 @@ rules:
   - '*'
   verbs:
   - '*'
+{{- end }}

--- a/deploy/helm/eunomia-operator/templates/clusterrolebinding-operator.yaml
+++ b/deploy/helm/eunomia-operator/templates/clusterrolebinding-operator.yaml
@@ -1,4 +1,5 @@
 {{- with .Values.eunomia.operator }}
+{{- if not .deployment.nsRbacOnly -}}
 # cluster role binding for the operator
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -12,4 +13,5 @@ roleRef:
   kind: ClusterRole
   name: eunomia-operator
   apiGroup: rbac.authorization.k8s.io
+{{- end }}
 {{- end }}

--- a/deploy/helm/eunomia-operator/templates/crd.yaml
+++ b/deploy/helm/eunomia-operator/templates/crd.yaml
@@ -1,1 +1,3 @@
+{{- if not .Values.eunomia.operator.deployment.nsRbacOnly -}}
 {{- .Files.Get "crds/eunomia_v1alpha1_gitopsconfig_crd.yaml" }}
+{{- end }}

--- a/deploy/helm/eunomia-operator/templates/deployment.yaml
+++ b/deploy/helm/eunomia-operator/templates/deployment.yaml
@@ -1,5 +1,5 @@
 {{- with .Values.eunomia.operator }}
-{{- if .deployment.enabled -}}
+{{- if and .deployment.enabled (not .deployment.nsRbacOnly) -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/deploy/helm/eunomia-operator/templates/ingress.yaml
+++ b/deploy/helm/eunomia-operator/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- with .Values.eunomia.operator }}
-{{- if .ingress.enabled -}}
+{{- if and .ingress.enabled (not .deployment.nsRbacOnly) -}}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:

--- a/deploy/helm/eunomia-operator/templates/namespace.yaml
+++ b/deploy/helm/eunomia-operator/templates/namespace.yaml
@@ -1,4 +1,5 @@
 {{- with .Values.eunomia.operator }}
+{{- if not .deployment.nsRbacOnly -}}
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -6,4 +7,5 @@ metadata:
     openshift.io/node-selector: ''
   name: {{ .namespace }}
 spec:
+{{- end }}
 {{- end }}

--- a/deploy/helm/eunomia-operator/templates/route.yaml
+++ b/deploy/helm/eunomia-operator/templates/route.yaml
@@ -1,5 +1,5 @@
 {{- with .Values.eunomia.operator }}
-{{- if .openshift.route.enabled -}}
+{{- if and .openshift.route.enabled (not .deployment.nsRbacOnly) -}}
 apiVersion: v1
 kind: Route
 metadata:

--- a/deploy/helm/eunomia-operator/templates/service.yaml
+++ b/deploy/helm/eunomia-operator/templates/service.yaml
@@ -1,4 +1,5 @@
 {{- with .Values.eunomia.operator }}
+{{- if not .deployment.nsRbacOnly -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -19,4 +20,5 @@ spec:
     port: 8383
     protocol: TCP
     targetPort: 8383
+{{- end }}
 {{- end }}

--- a/deploy/helm/eunomia-operator/values.yaml
+++ b/deploy/helm/eunomia-operator/values.yaml
@@ -3,6 +3,7 @@ eunomia:
     namespace: "eunomia-operator"
     deployment: 
       enabled: true
+      nsRbacOnly: false
     replicas: 1
     serviceAccount: "eunomia-operator"
 

--- a/scripts/deploy-to-local.sh
+++ b/scripts/deploy-to-local.sh
@@ -26,18 +26,13 @@ a local minikube or minishift docker registry.
 EOT
 }
 
-if [[ ! "${1:-}" ]]; then
+case "${1:-}" in
+  minikube) eval $(minikube docker-env);;
+  minishift) eval $(minishift docker-env);;
+  *)
     usage
     exit 1
-fi
-
-if [[ "$1" == minikube ]]; then
-    eval $(minikube docker-env)
-elif [[ "$1" == minishift ]]; then
-    eval $(minishift docker-env)
-else
-    usage
-    exit 1
-fi
+    ;;
+esac
 
 "$(dirname "$0")/build-images.sh" quay.io/kohlstechnology

--- a/template-processors/helm/bin/processTemplates.sh
+++ b/template-processors/helm/bin/processTemplates.sh
@@ -24,4 +24,9 @@ helm init --client-only
 helm repo update "${CLONED_TEMPLATE_GIT_DIR}"
 
 echo "Generating manifest files"
-helm template -f /tmp/eunomia_values_processed.yaml --output-dir "${MANIFEST_DIR}" --namespace "${NAMESPACE}" "${CLONED_TEMPLATE_GIT_DIR}"
+helm template \
+  -f /tmp/eunomia_values_processed.yaml \
+  ${TEMPLATE_PROCESSOR_ARGS:-} \
+  --output-dir "${MANIFEST_DIR}" \
+  --namespace "${NAMESPACE}" \
+  "${CLONED_TEMPLATE_GIT_DIR}"

--- a/test/e2e/events_test.go
+++ b/test/e2e/events_test.go
@@ -35,7 +35,7 @@ import (
 
 // TestJobEvents_JobSuccess verifies that a JobSucceeded event is emitted by
 // eunomia after a simple GitOpsConfig is executed.
-func TestJobEvents_JobSuccess(t *testing.T) {
+func TestJobEventsJobSuccess(t *testing.T) {
 	ctx := framework.NewTestCtx(t)
 	defer ctx.Cleanup()
 
@@ -43,6 +43,10 @@ func TestJobEvents_JobSuccess(t *testing.T) {
 	if err != nil {
 		t.Fatalf("could not get namespace: %v", err)
 	}
+	if err = SetupRbacInNamespace(namespace); err != nil {
+		t.Error(err)
+	}
+
 	defer DumpJobsLogsOnError(t, framework.Global, namespace)
 	err = framework.AddToFrameworkScheme(apis.AddToScheme, &gitopsv1alpha1.GitOpsConfigList{})
 	if err != nil {
@@ -133,7 +137,7 @@ func TestJobEvents_JobSuccess(t *testing.T) {
 
 // TestJobEvents_PeriodicJobSuccess verifies that a JobSuccessful event is
 // emitted by eunomia for a Periodic GitOpsConfig.
-func TestJobEvents_PeriodicJobSuccess(t *testing.T) {
+func TestJobEventsPeriodicJobSuccess(t *testing.T) {
 	ctx := framework.NewTestCtx(t)
 	defer ctx.Cleanup()
 
@@ -141,6 +145,10 @@ func TestJobEvents_PeriodicJobSuccess(t *testing.T) {
 	if err != nil {
 		t.Fatalf("could not get namespace: %v", err)
 	}
+	if err = SetupRbacInNamespace(namespace); err != nil {
+		t.Error(err)
+	}
+
 	defer DumpJobsLogsOnError(t, framework.Global, namespace)
 	err = framework.AddToFrameworkScheme(apis.AddToScheme, &gitopsv1alpha1.GitOpsConfigList{})
 	if err != nil {
@@ -228,7 +236,7 @@ func TestJobEvents_PeriodicJobSuccess(t *testing.T) {
 // TestJobEvents_JobFailed verifies that a JobFailed event is emitted by
 // eunomia if a Job implementing GitOpsConfig fails. In particular, a bad URI
 // is provided in the GitOpsConfig, to ensure that the Job will fail.
-func TestJobEvents_JobFailed(t *testing.T) {
+func TestJobEventsJobFailed(t *testing.T) {
 	if testing.Short() {
 		// FIXME: as of writing this test, "backoffLimit" in job.yaml is set to 4,
 		// which means we need to wait until 5 Pod retries fail, eventually
@@ -246,6 +254,10 @@ func TestJobEvents_JobFailed(t *testing.T) {
 	if err != nil {
 		t.Fatalf("could not get namespace: %v", err)
 	}
+	if err = SetupRbacInNamespace(namespace); err != nil {
+		t.Error(err)
+	}
+
 	defer DumpJobsLogsOnError(t, framework.Global, namespace)
 	err = framework.AddToFrameworkScheme(apis.AddToScheme, &gitopsv1alpha1.GitOpsConfigList{})
 	if err != nil {

--- a/test/e2e/helm_template_test.go
+++ b/test/e2e/helm_template_test.go
@@ -38,6 +38,10 @@ func TestHelmTemplate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("could not get namespace: %v", err)
 	}
+	if err = SetupRbacInNamespace(namespace); err != nil {
+		t.Error(err)
+	}
+
 	err = framework.AddToFrameworkScheme(apis.AddToScheme, &gitopsv1alpha1.GitOpsConfigList{})
 	if err != nil {
 		t.Fatal(err)
@@ -63,6 +67,7 @@ func TestHelmTemplate(t *testing.T) {
 			Namespace: namespace,
 		},
 		Spec: gitopsv1alpha1.GitOpsConfigSpec{
+			TemplateProcessorArgs: "--set namespace=" + namespace,
 			TemplateSource: gitopsv1alpha1.GitConfig{
 				URI:        eunomiaURI,
 				Ref:        eunomiaRef,

--- a/test/e2e/hierarchy_test.go
+++ b/test/e2e/hierarchy_test.go
@@ -38,6 +38,10 @@ func TestHierarchy(t *testing.T) {
 	if err != nil {
 		t.Fatalf("could not get namespace: %v", err)
 	}
+	if err = SetupRbacInNamespace(namespace); err != nil {
+		t.Error(err)
+	}
+
 	err = framework.AddToFrameworkScheme(apis.AddToScheme, &gitopsv1alpha1.GitOpsConfigList{})
 	if err != nil {
 		t.Fatal(err)
@@ -63,6 +67,7 @@ func TestHierarchy(t *testing.T) {
 			Namespace: namespace,
 		},
 		Spec: gitopsv1alpha1.GitOpsConfigSpec{
+			TemplateProcessorArgs: "--set namespace=" + namespace,
 			TemplateSource: gitopsv1alpha1.GitConfig{
 				URI:        eunomiaURI,
 				Ref:        eunomiaRef,

--- a/test/e2e/issue24_test.go
+++ b/test/e2e/issue24_test.go
@@ -32,7 +32,7 @@ import (
 	gitopsv1alpha1 "github.com/KohlsTechnology/eunomia/pkg/apis/eunomia/v1alpha1"
 )
 
-func TestIssue24_RemovedResourceGetsDeleted(t *testing.T) {
+func TestIssue24RemovedResourceGetsDeleted(t *testing.T) {
 	ctx := framework.NewTestCtx(t)
 	defer ctx.Cleanup()
 
@@ -40,6 +40,10 @@ func TestIssue24_RemovedResourceGetsDeleted(t *testing.T) {
 	if err != nil {
 		t.Fatalf("could not get namespace: %v", err)
 	}
+	if err = SetupRbacInNamespace(namespace); err != nil {
+		t.Error(err)
+	}
+
 	defer DumpJobsLogsOnError(t, framework.Global, namespace)
 	err = framework.AddToFrameworkScheme(apis.AddToScheme, &gitopsv1alpha1.GitOpsConfigList{})
 	if err != nil {

--- a/test/e2e/modes_test.go
+++ b/test/e2e/modes_test.go
@@ -32,7 +32,7 @@ import (
 	gitopsv1alpha1 "github.com/KohlsTechnology/eunomia/pkg/apis/eunomia/v1alpha1"
 )
 
-func TestModes_CreateReplaceDelete(t *testing.T) {
+func TestModesCreateReplaceDelete(t *testing.T) {
 	ctx := framework.NewTestCtx(t)
 	defer ctx.Cleanup()
 
@@ -40,6 +40,10 @@ func TestModes_CreateReplaceDelete(t *testing.T) {
 	if err != nil {
 		t.Fatalf("could not get namespace: %v", err)
 	}
+	if err = SetupRbacInNamespace(namespace); err != nil {
+		t.Error(err)
+	}
+
 	defer DumpJobsLogsOnError(t, framework.Global, namespace)
 	err = framework.AddToFrameworkScheme(apis.AddToScheme, &gitopsv1alpha1.GitOpsConfigList{})
 	if err != nil {

--- a/test/e2e/ocp_template_test.go
+++ b/test/e2e/ocp_template_test.go
@@ -42,6 +42,10 @@ func disabledOCPTemplate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("could not get namespace: %v", err)
 	}
+	if err = SetupRbacInNamespace(namespace); err != nil {
+		t.Error(err)
+	}
+
 	err = framework.AddToFrameworkScheme(apis.AddToScheme, &gitopsv1alpha1.GitOpsConfigList{})
 	if err != nil {
 		t.Fatal(err)

--- a/test/e2e/status_test.go
+++ b/test/e2e/status_test.go
@@ -33,7 +33,7 @@ import (
 	gitopsv1alpha1 "github.com/KohlsTechnology/eunomia/pkg/apis/eunomia/v1alpha1"
 )
 
-func TestStatus_Success(t *testing.T) {
+func TestStatusSuccess(t *testing.T) {
 	ctx := framework.NewTestCtx(t)
 	defer ctx.Cleanup()
 
@@ -41,6 +41,10 @@ func TestStatus_Success(t *testing.T) {
 	if err != nil {
 		t.Fatalf("could not get namespace: %v", err)
 	}
+	if err = SetupRbacInNamespace(namespace); err != nil {
+		t.Error(err)
+	}
+
 	defer DumpJobsLogsOnError(t, framework.Global, namespace)
 	err = framework.AddToFrameworkScheme(apis.AddToScheme, &gitopsv1alpha1.GitOpsConfigList{})
 	if err != nil {
@@ -142,7 +146,7 @@ func TestStatus_Success(t *testing.T) {
 	}
 }
 
-func TestStatus_PeriodicJobSuccess(t *testing.T) {
+func TestStatusPeriodicJobSuccess(t *testing.T) {
 	ctx := framework.NewTestCtx(t)
 	defer ctx.Cleanup()
 
@@ -150,6 +154,10 @@ func TestStatus_PeriodicJobSuccess(t *testing.T) {
 	if err != nil {
 		t.Fatalf("could not get namespace: %v", err)
 	}
+	if err = SetupRbacInNamespace(namespace); err != nil {
+		t.Error(err)
+	}
+
 	defer DumpJobsLogsOnError(t, framework.Global, namespace)
 	err = framework.AddToFrameworkScheme(apis.AddToScheme, &gitopsv1alpha1.GitOpsConfigList{})
 	if err != nil {
@@ -268,7 +276,7 @@ func TestStatus_PeriodicJobSuccess(t *testing.T) {
 	}
 }
 
-func TestStatus_Failure(t *testing.T) {
+func TestStatusFailure(t *testing.T) {
 	if testing.Short() {
 		// FIXME: as of writing this test, "backoffLimit" in job.yaml is set to 4,
 		// which means we need to wait until 5 Pod retries fail, eventually
@@ -286,6 +294,10 @@ func TestStatus_Failure(t *testing.T) {
 	if err != nil {
 		t.Fatalf("could not get namespace: %v", err)
 	}
+	if err = SetupRbacInNamespace(namespace); err != nil {
+		t.Error(err)
+	}
+
 	defer DumpJobsLogsOnError(t, framework.Global, namespace)
 	err = framework.AddToFrameworkScheme(apis.AddToScheme, &gitopsv1alpha1.GitOpsConfigList{})
 	if err != nil {


### PR DESCRIPTION
<!--
    Please read https://github.com/KohlsTechnology/eunomia/blob/master/.github/CONTRIBUTING.md before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->
Run each test function in separate namespace.

Add SetupRbacInNamespace function to make it possible to deploy a
service account to on-the-fly generated namespace (during tests).

In each test deploy eunomia-operator service account bound to
eunomia-operator role. Also remove underscores from test function names
to make per-namespace tests possible because test namespaces created
dynamically by operator-sdk framework take function name as part of a
namespace (and such cannot have an underscore).

Make it possible to use TEMPLATE_PROCESSOR_ARGS env variable in helm
template processor.

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #211 

**Type of change**

<!-- Please delete options that are not relevant. -->

* New feature (non-breaking change which adds functionality)

**Checklist**

- [x] Unit tests and e2e tests updated
- [ ] Documentation updated (no need for this PR)
