### PR TITLE
Add kubernetes liveliness(health) check uri

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -145,11 +145,16 @@ func main() {
 	// 	log.Info(err.Error())
 	// }
 
-	// Set up WebHook listener
+	// Set up WebHook listener and healthz endpoint
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/webhook/", func(w http.ResponseWriter, r *http.Request) {
 		handler.WebhookHandler(w, r, gitopsconfig.NewReconciler(mgr))
+	})
+
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("ok\n"))
 	})
 
 	log.Info("Starting the Web Server")

--- a/deploy/helm/eunomia-operator/templates/deployment.yaml
+++ b/deploy/helm/eunomia-operator/templates/deployment.yaml
@@ -31,6 +31,12 @@ spec:
               value: "eunomia-operator"
           resources:
             {{- toYaml .resources | nindent 12 }}
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+            initialDelaySeconds: 30
+            periodSeconds: 5
       {{- with .nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
<!--
    Please read https://github.com/KohlsTechnology/eunomia/blob/master/.github/CONTRIBUTING.md before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

Add liveliness endpoint at /healthz for eunomia-operatator and add
livenessProbe to deployment definition. This is done in order for
kubernetes to know when pod is healthy or need to be restarted.

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #248 

**Type of change**

* New feature (non-breaking change which adds functionality)

**Checklist**

- [not needed ] Unit tests and e2e tests updated
- [not needed] Documentation updated
