### PR TITLE
pkg/controller/gitopsconfig: delete stuck jobs when finalizing

### DIFF
--- a/build/job-templates/cronjob.yaml
+++ b/build/job-templates/cronjob.yaml
@@ -8,7 +8,7 @@ spec:
   jobTemplate:
     metadata:
       labels:
-        "gitopsconfig.eunomia.kohls.io/jobOwner": "{{ .Config.ObjectMeta.Name }}"
+        gitopsconfig.eunomia.kohls.io/jobOwner: "{{ .Config.ObjectMeta.Name }}"
     spec:
       template:
         spec:

--- a/build/job-templates/cronjob.yaml
+++ b/build/job-templates/cronjob.yaml
@@ -6,6 +6,9 @@ metadata:
 spec:
   schedule: "{{ getCron .Config }}"
   jobTemplate:
+    metadata:
+      labels:
+        "gitopsconfig.eunomia.kohls.io/jobOwner": "{{ .Config.ObjectMeta.Name }}"
     spec:
       template:
         spec:

--- a/build/job-templates/job.yaml
+++ b/build/job-templates/job.yaml
@@ -4,7 +4,8 @@ metadata:
   name: gitopsconfig-{{ .Config.ObjectMeta.Name }}-{{ getID }}
   namespace: {{ .Config.ObjectMeta.Namespace }}
   labels:
-    action: {{ .Action }} 
+    action: {{ .Action }}
+    "gitopsconfig.eunomia.kohls.io/jobOwner": "{{ .Config.ObjectMeta.Name }}"
 spec:
   template:
     spec:                                                    

--- a/build/job-templates/job.yaml
+++ b/build/job-templates/job.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: {{ .Config.ObjectMeta.Namespace }}
   labels:
     action: {{ .Action }}
-    "gitopsconfig.eunomia.kohls.io/jobOwner": "{{ .Config.ObjectMeta.Name }}"
+    gitopsconfig.eunomia.kohls.io/jobOwner: "{{ .Config.ObjectMeta.Name }}"
 spec:
   template:
     spec:                                                    

--- a/deploy/helm/eunomia-operator/templates/clusterrole-operators.yaml
+++ b/deploy/helm/eunomia-operator/templates/clusterrole-operators.yaml
@@ -17,6 +17,7 @@ rules:
   - ''
   resources:
   - namespaces
+  - pods
   verbs:
   - get
   - list

--- a/pkg/controller/gitopsconfig/controller.go
+++ b/pkg/controller/gitopsconfig/controller.go
@@ -473,7 +473,7 @@ func (r *Reconciler) manageDeletion(instance *gitopsv1alpha1.GitOpsConfig) (reco
 		log.Error(err, "unable to create deletion job", "instance", instance.Name)
 		return reconcile.Result{}, err
 	}
-	//we return because we need to wait for the job to stop
+	// we return because we need to wait for the job to stop
 	return reconcile.Result{
 		Requeue:      true,
 		RequeueAfter: time.Second * 5,
@@ -496,6 +496,7 @@ func (r *Reconciler) removeFinalizer(ctx context.Context, instance *gitopsv1alph
 		log.Error(err, "GitOpsConfig finalizer unable to remove itself", "instance", instance.Name)
 		return reconcile.Result{}, xerrors.Errorf("GitOpsConfig finalizer unable to remove itself from %q: %w", instance.Name, err)
 	}
+	log.Info("GitOpsConfig finalizer successfully removed itself from CR", "instance", instance.Name)
 	return reconcile.Result{}, nil
 }
 
@@ -530,6 +531,10 @@ func ownedJobs(ctx context.Context, kube client.Client, owner *gitopsv1alpha1.Gi
 	return jobs.Items, nil
 }
 
+// jobContainerStatus retrieves the job's pod from kube cluster, and returns
+// the status of its container. If the job controls more than one pod, or the
+// pod contains more than one container, an error is returned. If the job
+// controls no pods, nil is returned.
 func jobContainerStatus(ctx context.Context, kube client.Client, job *batchv1.Job) (*corev1.ContainerState, error) {
 	// Find pod(s) of the job
 	pods := corev1.PodList{}

--- a/pkg/controller/gitopsconfig/controller.go
+++ b/pkg/controller/gitopsconfig/controller.go
@@ -50,6 +50,7 @@ var log = logf.Log.WithName(controllerName)
 const (
 	tagInitialized string = "gitopsconfig.eunomia.kohls.io/initialized"
 	tagFinalizer   string = "gitopsconfig.eunomia.kohls.io/finalizer"
+	tagJobOwner    string = "gitopsconfig.eunomia.kohls.io/jobOwner"
 	controllerName string = "gitopsconfig-controller"
 )
 

--- a/pkg/controller/gitopsconfig/controller.go
+++ b/pkg/controller/gitopsconfig/controller.go
@@ -393,7 +393,7 @@ func (r *Reconciler) manageDeletion(instance *gitopsv1alpha1.GitOpsConfig) (reco
 		return reconcile.Result{}, nil
 	}
 
-	// To avoid a deadlock situation let's check if the namespace in which we are is maybe being deleted?
+	// To avoid a deadlock situation let's check if the namespace in which we are is maybe being deleted
 	ns := &corev1.Namespace{}
 	err := r.client.Get(context.TODO(), types.NamespacedName{
 		Name: instance.GetNamespace(),
@@ -403,8 +403,9 @@ func (r *Reconciler) manageDeletion(instance *gitopsv1alpha1.GitOpsConfig) (reco
 		return reconcile.Result{}, xerrors.Errorf("GitOpsConfig finalizer unable to lookup instance's namespace for %q: %w", instance.Name, err)
 	}
 	if !ns.DeletionTimestamp.IsZero() {
-		//namespace is being deleted
-		// the best we can do in this situation is to let the instance be deleted and hope that this instance was creating objects only in this namespace
+		// Namespace is being deleted. The best we can do in this situation is
+		// to let the instance be deleted and hope that this instance was
+		// creating objects only in this namespace
 		log.Info("Namespace is being deleted, removing finalizer", "namespace", instance.Namespace, "instance", instance.Name)
 		return r.removeFinalizer(context.TODO(), instance)
 	}
@@ -458,9 +459,9 @@ func (r *Reconciler) manageDeletion(instance *gitopsv1alpha1.GitOpsConfig) (reco
 		}
 		done := deleters[0].Status.Succeeded > 0
 		if !done {
-			//if it's not succeeded we wait for 5 seconds
-			//TODO add logic to stop at a certain point ... or not ...
-			//TODO add exponential backoff, possibly like in CronJob
+			// if it's not succeeded we wait for 5 seconds
+			// TODO add logic to stop at a certain point ... or not ...
+			// TODO add exponential backoff, possibly like in CronJob
 			return reconcile.Result{RequeueAfter: 5 * time.Second}, nil
 		}
 		return r.removeFinalizer(context.TODO(), instance)

--- a/pkg/controller/gitopsconfig/controller_test.go
+++ b/pkg/controller/gitopsconfig/controller_test.go
@@ -326,6 +326,12 @@ func TestDeleteRemovingFinalizer(t *testing.T) {
 	cl := fake.NewFakeClient(objs...)
 	r := &Reconciler{client: cl, scheme: s}
 
+	// Create a namespace
+	err := cl.Create(context.TODO(), ns)
+	if err != nil {
+		log.Error(err, "Namespace", "Failed to create namespace")
+	}
+
 	nsn := types.NamespacedName{
 		Name:      name,
 		Namespace: namespace,
@@ -339,7 +345,7 @@ func TestDeleteRemovingFinalizer(t *testing.T) {
 
 	// Add a finalizer to the CRD
 	gitops.ObjectMeta.Finalizers = append(gitops.ObjectMeta.Finalizers, "gitopsconfig.eunomia.kohls.io/finalizer")
-	err := cl.Update(context.Background(), gitops)
+	err = cl.Update(context.Background(), gitops)
 	if err != nil {
 		log.Error(err, "Add Finalizer", "Failed adding finalizer to CRD")
 	}

--- a/pkg/controller/gitopsconfig/status_updater.go
+++ b/pkg/controller/gitopsconfig/status_updater.go
@@ -115,6 +115,7 @@ func (u *statusUpdater) OnUpdate(oldObj, newObj interface{}) {
 		log.Info("Status is already set, with newer StartTime - skipping; reordered events?", "GitOpsConfig", gitops.Name)
 		return
 	}
+	// TODO: don't update if status didn't change
 	gitops.Status = status
 	err = u.client.Status().Update(context.TODO(), gitops)
 	if err != nil {

--- a/test/e2e/issue216_test.go
+++ b/test/e2e/issue216_test.go
@@ -1,0 +1,181 @@
+// +build e2e
+
+/*
+Copyright 2020 Kohl's Department Stores, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	framework "github.com/operator-framework/operator-sdk/pkg/test"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	"github.com/KohlsTechnology/eunomia/pkg/apis"
+	gitopsv1alpha1 "github.com/KohlsTechnology/eunomia/pkg/apis/eunomia/v1alpha1"
+)
+
+func TestIssue216InvalidImageDeleted(t *testing.T) {
+	ctx := framework.NewTestCtx(t)
+	defer ctx.Cleanup()
+
+	namespace, err := ctx.GetNamespace()
+	if err != nil {
+		t.Fatalf("could not get namespace: %v", err)
+	}
+	if err = SetupRbacInNamespace(namespace); err != nil {
+		t.Error(err)
+	}
+
+	defer DumpJobsLogsOnError(t, framework.Global, namespace)
+	err = framework.AddToFrameworkScheme(apis.AddToScheme, &gitopsv1alpha1.GitOpsConfigList{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	eunomiaURI, found := os.LookupEnv("EUNOMIA_URI")
+	if !found {
+		eunomiaURI = "https://github.com/kohlstechnology/eunomia"
+	}
+	eunomiaRef, found := os.LookupEnv("EUNOMIA_REF")
+	if !found {
+		eunomiaRef = "master"
+	}
+
+	// Step 1: create a simple CR with an invalid template-processor URL
+
+	gitops := &gitopsv1alpha1.GitOpsConfig{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "GitOpsConfig",
+			APIVersion: "eunomia.kohls.io/v1alpha1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "gitops-issue216",
+			Namespace: namespace,
+			Finalizers: []string{
+				"gitopsconfig.eunomia.kohls.io/finalizer",
+			},
+		},
+		Spec: gitopsv1alpha1.GitOpsConfigSpec{
+			TemplateSource: gitopsv1alpha1.GitConfig{
+				URI:        eunomiaURI,
+				Ref:        eunomiaRef,
+				ContextDir: "test/e2e/testdata/events/test-a",
+			},
+			ParameterSource: gitopsv1alpha1.GitConfig{
+				URI:        eunomiaURI,
+				Ref:        eunomiaRef,
+				ContextDir: "test/e2e/testdata/empty-yaml",
+			},
+			Triggers: []gitopsv1alpha1.GitOpsTrigger{
+				{Type: "Change"},
+			},
+			TemplateProcessorImage: "quay.io/kohlstechnology/invalid:bad",
+			ResourceHandlingMode:   "Apply",
+			ResourceDeletionMode:   "Delete",
+			ServiceAccountRef:      "eunomia-operator",
+		},
+	}
+	gitops.Annotations = map[string]string{"gitopsconfig.eunomia.kohls.io/initialized": "true"}
+
+	err = framework.Global.Client.Create(context.TODO(), gitops, &framework.CleanupOptions{TestContext: ctx, Timeout: timeout, RetryInterval: retryInterval})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Step 2: Wait until Job exists (in incomplete state)
+
+	err = wait.Poll(retryInterval, timeout, func() (done bool, err error) {
+		const name = "gitopsconfig-gitops-issue216-"
+		pod, err := GetPod(namespace, name, "quay.io/kohlstechnology/invalid:bad", framework.Global.KubeClient)
+		switch {
+		case apierrors.IsNotFound(err):
+			t.Logf("Waiting for availability of %s pod", name)
+			return false, nil
+		case err != nil:
+			return false, err
+		case pod != nil && pod.Status.Phase == "Pending":
+			return true, nil
+		case pod != nil:
+			t.Logf("Waiting for error in pod %s; status: %s", name, debugJSON(pod.Status))
+			return false, nil
+		default:
+			t.Logf("Waiting for error in pod %s", name)
+			return false, nil
+		}
+	})
+	if err != nil {
+		t.Error(err)
+	}
+
+	// Step 3: Delete CR
+
+	t.Logf("Deleting CR")
+	err = framework.Global.Client.Delete(context.TODO(), gitops)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Step 4: Wait to verify that CR got successfully removed
+
+	err = wait.Poll(retryInterval, timeout, func() (done bool, err error) {
+		found := gitopsv1alpha1.GitOpsConfig{}
+		err = framework.Global.Client.Get(context.TODO(),
+			types.NamespacedName{Namespace: namespace, Name: gitops.ObjectMeta.Name},
+			&found)
+		switch {
+		case apierrors.IsNotFound(err):
+			t.Logf("Confirmed GitOpsConfig shutdown")
+			return true, nil
+		case err != nil:
+			return false, err
+		default:
+			t.Logf("Waiting for shutdown of GitOpsConfig; status: %s", debugJSON(found.Status))
+			return false, nil
+		}
+	})
+	if err != nil {
+		t.Error(err)
+	}
+
+	// Step 5: Wait until no Pods exist for this CR
+
+	err = wait.Poll(retryInterval, timeout, func() (done bool, err error) {
+		const name = "gitopsconfig-gitops-issue216-"
+		pod, err := GetPod(namespace, name, "", framework.Global.KubeClient)
+		switch {
+		case apierrors.IsNotFound(err):
+			t.Logf("Confirmed no more pods found")
+			return true, nil
+		case err != nil:
+			return false, err
+		case pod == nil:
+			t.Logf("Confirmed no more %s pods found", name)
+			return true, nil
+		default:
+			t.Logf("Waiting for shutdown of %s pod; status: %s", name, debugJSON(pod.Status))
+			return false, nil
+		}
+	})
+	if err != nil {
+		t.Error(err)
+	}
+}


### PR DESCRIPTION
<!--
    Please read https://github.com/KohlsTechnology/eunomia/blob/master/.github/CONTRIBUTING.md before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->
In GitOpsConfig finalizer, find and delete any stuck Jobs.

Previously, if GitOpsConfig had a bad template processor image path, its
Job would never complete, stuck in a "Waiting" phase, with an error
message. When deleting a GitOpsConfig, the finalizer would then try to
create another Job, which would also get stuck, making it impossible to
complete deletion of GitOpsConfig.

This PR changes the algorithm of GitOpsConfig finalizer to
enable handling one more special case, when a Job is stuck with one of
known error messages. In such case, finalizer now deletes the Job (with
its corresponding Pods), and doesn't create a new finalizer Job.

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #216.



**Type of change**

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)

**Checklist**

- [x] Unit tests and e2e tests updated
- [ ] ~~Documentation updated~~  N/A
