### PR TITLE
cmd/manager: expose version info

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -11,6 +11,11 @@ assignees: ''
 
 **What version of eunomia are you using?**
 
+<details><summary><code>kubectl exec $EUNOMIA_POD curl localhost:8383/metrics</code> Output</summary><br><pre>
+$ kubectl get -n eunomia-operator endpoints/eunomia-operator -o jsonpath='{.subsets[*].addresses[*].targetRef.name}' | xargs -I% kubectl exec -n eunomia-operator % -- curl -sS localhost:8383/metrics | grep eunomia_build_info
+
+</pre></details>
+
 eunomia version:
 
 **Does this issue reproduce with the latest release?**

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -20,6 +20,11 @@ assignees: ''
 
 **What version of eunomia are you using?**
 
+<details><summary><code>kubectl exec $EUNOMIA_POD curl localhost:8383/metrics</code> Output</summary><br><pre>
+$ kubectl get -n eunomia-operator endpoints/eunomia-operator -o jsonpath='{.subsets[*].addresses[*].targetRef.name}' | xargs -I% kubectl exec -n eunomia-operator % -- curl -sS localhost:8383/metrics | grep eunomia_build_info
+
+</pre></details>
+
 eunomia version:
 
 **Additional context**

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -53,7 +53,7 @@ var (
 var log = logf.Log.WithName("cmd")
 
 func printVersion() {
-	log.Info(fmt.Sprintf("Eunomia version: %s", version.Version))
+	log.Info(fmt.Sprintf("Eunomia version: %s (build date: %s, branch: %s, git SHA1: %s)", version.Version, version.BuildDate, version.Branch, version.GitSHA1))
 	log.Info(fmt.Sprintf("Go Version: %s", runtime.Version()))
 	log.Info(fmt.Sprintf("Go OS/Arch: %s/%s", runtime.GOOS, runtime.GOARCH))
 	log.Info(fmt.Sprintf("Version of operator-sdk: %v", sdkVersion.Version))
@@ -92,11 +92,17 @@ func main() {
 		prometheus.GaugeOpts{
 			Namespace: "eunomia",
 			Name:      "build_info",
-			Help:      "A metric with a constant '1' value labeled by version from which eunomia was built, and other useful build information.",
+			Help: "A metric with a constant '1' value labeled by version from " +
+				"which eunomia was built, and other useful build information.",
 		},
-		[]string{"version", "goversion", "operatorsdk"},
+		[]string{
+			"version", "builddate", "branch", "gitsha1",
+			"goversion", "operatorsdk",
+		},
 	)
-	buildInfo.WithLabelValues(version.Version, runtime.Version(), sdkVersion.Version).Set(1)
+	buildInfo.WithLabelValues(
+		version.Version, version.BuildDate, version.Branch, version.GitSHA1,
+		runtime.Version(), sdkVersion.Version).Set(1)
 	metrics.Registry.MustRegister(buildInfo)
 
 	namespace, err := k8sutil.GetWatchNamespace()

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -53,6 +53,7 @@ var (
 var log = logf.Log.WithName("cmd")
 
 func printVersion() {
+	log.Info(fmt.Sprintf("Eunomia version: %s", version.Version))
 	log.Info(fmt.Sprintf("Go Version: %s", runtime.Version()))
 	log.Info(fmt.Sprintf("Go OS/Arch: %s/%s", runtime.GOOS, runtime.GOARCH))
 	log.Info(fmt.Sprintf("Version of operator-sdk: %v", sdkVersion.Version))
@@ -67,6 +68,8 @@ func main() {
 	// controller-runtime)
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
 
+	versionFlag := pflag.Bool("version", false, "print version information and exit")
+
 	pflag.Parse()
 
 	// Use a zap logr.Logger implementation. If none of the zap
@@ -80,6 +83,9 @@ func main() {
 	logf.SetLogger(zap.Logger())
 
 	printVersion()
+	if *versionFlag {
+		os.Exit(0)
+	}
 
 	// Register a Prometheus-formatted metric displaying app version & other useful build info.
 	buildInfo := prometheus.NewGaugeVec(

--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/operator-framework/operator-sdk v0.8.2-0.20190522220659-031d71ef8154
 	github.com/pborman/uuid v0.0.0-20180906182336-adf5a7427709 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
+	github.com/prometheus/client_golang v0.9.3-0.20190127221311-3c4408c8b829
 	github.com/sergi/go-diff v1.0.0 // indirect
 	github.com/spf13/pflag v1.0.3
 	github.com/stretchr/testify v1.3.0


### PR DESCRIPTION
<!--
    Please read https://github.com/KohlsTechnology/eunomia/blob/master/.github/CONTRIBUTING.md before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->
Add a Prometheus metric exposing eunomia version, and a command-line flag doing the same. This makes it easy to find out what version of eunomia is running in a cluster (via metric) or is available for running (via flag).

Also, in issue templates, show a command that can be used to easily retrieve eunomia version from a cluster. This is intended to help issue reporters give us precise information with as little effort on their side as possible.

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #260

**Type of change**

<!-- Please delete options that are not relevant. -->


* New feature (non-breaking change which adds functionality)

**Checklist**

- [ ] Unit tests and e2e tests updated — *simple change, tests not added*
- [ ] Documentation updated — *N/A*
