### PR TITLE
template-progress/ocp-template: downgrade oc to 3.11

### DIFF
--- a/deploy/helm/eunomia-operator/templates/clusterrole-operators.yaml
+++ b/deploy/helm/eunomia-operator/templates/clusterrole-operators.yaml
@@ -11,7 +11,7 @@ rules:
   - jobs
   - cronjobs
   verbs:
-  - '*'  
+  - '*'
 # needed by operator logic when handling finalizers
 - apiGroups:
   - ''
@@ -29,11 +29,19 @@ rules:
   - events
   verbs:
   - create
-# operator's resources  
+# operator's resources
 - apiGroups:
   - eunomia.kohls.io
   resources:
   - '*'
   verbs:
   - '*'
+{{- if .Values.eunomia.operator.openshift.enabled }}
+- apiGroups:
+  - template.openshift.io
+  resources:
+  - processedtemplates
+  verbs:
+  - '*'
+{{- end }}
 {{- end }}

--- a/deploy/helm/eunomia-operator/values.yaml
+++ b/deploy/helm/eunomia-operator/values.yaml
@@ -52,5 +52,6 @@ eunomia:
         memory: 256Mi
 
     openshift:
+      enabled: false
       route:
         enabled: false

--- a/scripts/ocp-test.sh
+++ b/scripts/ocp-test.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+
+# Copyright 2020 Kohl's Department Stores, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euxo pipefail
+
+export TEST_NAMESPACE=test-eunomia-operator
+export GO111MODULE=on
+
+# Check if minishift is running
+minishift status || {
+    echo "Minishift is not running, aborting tests"
+    exit 1
+}
+
+eval "$(minishift oc-env)"
+# FIXME: sort out permissions; for now using admin, to have something working as a first step
+oc login -u system:admin
+if ! oc get projects | grep -q test-eunomia-operator; then
+    oc new-project test-eunomia-operator
+fi
+oc project test-eunomia-operator
+
+# Ensure clean workspace
+if [[ $(oc get namespace $TEST_NAMESPACE) ]]; then
+    oc delete namespace $TEST_NAMESPACE
+fi
+
+eval "$(minishift docker-env)"
+GOOS=linux make e2e-test-images
+
+# Eunomia setup
+helm template deploy/helm/eunomia-operator/ \
+    --set eunomia.operator.openshift.enabled=true \
+    --set eunomia.operator.image.tag=dev \
+    --set eunomia.operator.image.pullPolicy=Never \
+    --set eunomia.operator.namespace=$TEST_NAMESPACE | oc apply -f -
+
+# Deployment test
+oc wait --for=condition=available --timeout=30s deployment/eunomia-operator -n $TEST_NAMESPACE
+podname=$(oc get pods -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' -n $TEST_NAMESPACE)
+if oc exec "${podname}" date -n $TEST_NAMESPACE; then
+    echo "Eunomia deployment successful"
+else
+    echo "Eunomia deployment failed"
+    exit 1
+fi
+
+## Testing templates-processors/ocp-template
+
+#Test ocp-hello-cr1
+ocp_hello_cr1() {
+    timeout=30
+    # FIXME: below CR should be modified by the script to use PR branch ref instead of master
+    oc apply -f test/e2e/testdata/simple/ocp-hello-cr1.yaml
+    while ((--timeout)) && [[ "$(oc get po -n test-eunomia-operator -l app=helloworld -o=jsonpath="{range .items[*]}{.status.phase}{'\n'}{end}")" != "Running" ]]; do
+        echo "waiting for ocp-hello-cr1 deployment: remaining $timeout sec..."
+        sleep 1
+    done
+    if [[ $timeout == 0 ]]; then
+        echo "Example ocp-hello-cr1 Test FAILED"
+        exit 1
+    fi
+    echo "Example ocp-hello-cr1 Test Passed"
+}
+
+ocp_hello_cr1
+
+# FIXME: the helloworld pod is still alive after below line; ownedKinds is empty, probably because missing RBAC policies
+oc delete -f test/e2e/testdata/simple/ocp-hello-cr1.yaml
+
+oc delete namespace test-eunomia-operator
+

--- a/scripts/ocp-test.sh
+++ b/scripts/ocp-test.sh
@@ -28,14 +28,14 @@ minishift status || {
 eval "$(minishift oc-env)"
 # FIXME: sort out permissions; for now using admin, to have something working as a first step
 oc login -u system:admin
-if ! oc get projects | grep -q test-eunomia-operator; then
-    oc new-project test-eunomia-operator
+if ! oc get projects | grep -q "${TEST_NAMESPACE}"; then
+    oc new-project "${TEST_NAMESPACE}"
 fi
-oc project test-eunomia-operator
+oc project "${TEST_NAMESPACE}"
 
 # Ensure clean workspace
-if [[ $(oc get namespace $TEST_NAMESPACE) ]]; then
-    oc delete namespace $TEST_NAMESPACE
+if [[ $(oc get namespace "${TEST_NAMESPACE}") ]]; then
+    oc delete namespace "${TEST_NAMESPACE}"
 fi
 
 eval "$(minishift docker-env)"
@@ -46,12 +46,12 @@ helm template deploy/helm/eunomia-operator/ \
     --set eunomia.operator.openshift.enabled=true \
     --set eunomia.operator.image.tag=dev \
     --set eunomia.operator.image.pullPolicy=Never \
-    --set eunomia.operator.namespace=$TEST_NAMESPACE | oc apply -f -
+    --set eunomia.operator.namespace="${TEST_NAMESPACE}" | oc apply -f -
 
 # Deployment test
-oc wait --for=condition=available --timeout=30s deployment/eunomia-operator -n $TEST_NAMESPACE
-podname=$(oc get pods -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' -n $TEST_NAMESPACE)
-if oc exec "${podname}" date -n $TEST_NAMESPACE; then
+oc wait --for=condition=available --timeout=30s deployment/eunomia-operator -n "${TEST_NAMESPACE}"
+podname=$(oc get pods -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' -n "${TEST_NAMESPACE}")
+if oc exec "${podname}" date -n "${TEST_NAMESPACE}"; then
     echo "Eunomia deployment successful"
 else
     echo "Eunomia deployment failed"
@@ -59,13 +59,14 @@ else
 fi
 
 ## Testing templates-processors/ocp-template
+# FIXME: we should put GitOpsConfig in a different namespace than eunomia-operator itself
 
 #Test ocp-hello-cr1
 ocp_hello_cr1() {
     timeout=30
     # FIXME: below CR should be modified by the script to use PR branch ref instead of master
     oc apply -f test/e2e/testdata/simple/ocp-hello-cr1.yaml
-    while ((--timeout)) && [[ "$(oc get po -n test-eunomia-operator -l app=helloworld -o=jsonpath="{range .items[*]}{.status.phase}{'\n'}{end}")" != "Running" ]]; do
+    while ((--timeout)) && [[ "$(oc get po -n "${TEST_NAMESPACE}" -l app=helloworld -o=jsonpath="{range .items[*]}{.status.phase}{'\n'}{end}")" != "Running" ]]; do
         echo "waiting for ocp-hello-cr1 deployment: remaining $timeout sec..."
         sleep 1
     done
@@ -81,5 +82,4 @@ ocp_hello_cr1
 # FIXME: the helloworld pod is still alive after below line; ownedKinds is empty, probably because missing RBAC policies
 oc delete -f test/e2e/testdata/simple/ocp-hello-cr1.yaml
 
-oc delete namespace test-eunomia-operator
-
+oc delete namespace "${TEST_NAMESPACE}"

--- a/template-processors/ocp-template/Dockerfile.in
+++ b/template-processors/ocp-template/Dockerfile.in
@@ -1,11 +1,10 @@
 FROM @REPOSITORY@/eunomia-base:@IMAGE_TAG@
 
-ENV OC_VERSION=4.1.8
+ENV OC_VERSION=3.11.170
 
 USER root
-
-RUN curl -O http://mirror.openshift.com/pub/openshift-v4/clients/ocp/${OC_VERSION}/openshift-client-linux-${OC_VERSION}.tar.gz \
-  && tar --directory /usr/bin -zxvf openshift-client-linux-${OC_VERSION}.tar.gz oc
+RUN curl -O http://mirror.openshift.com/pub/openshift-v3/clients/${OC_VERSION}/linux/oc.tar.gz \
+  && tar --directory /usr/bin -zxvf oc.tar.gz oc
 
 COPY bin/processTemplates.sh /usr/local/bin/processTemplates.sh
 

--- a/template-processors/ocp-template/bin/processTemplates.sh
+++ b/template-processors/ocp-template/bin/processTemplates.sh
@@ -20,4 +20,9 @@ set -euxo pipefail
 ## we assume that in $CLONED_PARAMETER_GIT_DIR there is a parameter file called parameters.ini
 
 envsubst <"$CLONED_PARAMETER_GIT_DIR/parameters.ini" >"$CLONED_PARAMETER_GIT_DIR/parameters_subst.ini"
-oc process -f "$CLONED_TEMPLATE_GIT_DIR/template.yaml" --param-file="$CLONED_PARAMETER_GIT_DIR/parameters_subst.ini" >"$MANIFEST_DIR/manifests.yaml"
+# shellcheck disable=SC2086
+oc process \
+    -f "$CLONED_TEMPLATE_GIT_DIR/template.yaml" \
+    --param-file="$CLONED_PARAMETER_GIT_DIR/parameters_subst.ini" \
+    ${TEMPLATE_PROCESSOR_ARGS:-} \
+    >"$MANIFEST_DIR/manifests.yaml"

--- a/test/e2e/testdata/simple/ocp-hello-cr1.yaml
+++ b/test/e2e/testdata/simple/ocp-hello-cr1.yaml
@@ -1,0 +1,19 @@
+apiVersion: eunomia.kohls.io/v1alpha1
+kind: GitOpsConfig
+metadata:
+  name: hello-world-ocp
+spec:
+  templateSource:
+    uri: https://github.com/KohlsTechnology/eunomia
+    ref: master
+    contextDir: test/e2e/testdata/simple/templates
+  parameterSource:
+    ref: master
+    contextDir: test/e2e/testdata/simple/parameters
+  triggers:
+  - type: Change
+  serviceAccountRef: eunomia-operator
+  templateProcessorImage: quay.io/kohlstechnology/eunomia-ocp-templates:latest
+  resourceHandlingMode: Apply
+  resourceDeletionMode: Delete
+

--- a/test/e2e/testdata/simple/templates/template.yaml
+++ b/test/e2e/testdata/simple/templates/template.yaml
@@ -10,6 +10,8 @@ objects:
   kind: Pod
   metadata:
     name: helloworld
+    labels:
+      app: helloworld
   spec:
     serviceAccount: eunomia-operator
     serviceAccountName: eunomia-operator


### PR DESCRIPTION
<!--
    Please read https://github.com/KohlsTechnology/eunomia/blob/master/.github/CONTRIBUTING.md before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

Fixes #236. Related quotes providing the rationale:

> The environment I'm running in restricts the version of kubectl/oc
> that can be used. Using the oc 4.x client is disallowed in my
> environment. [...]
>
> I am hoping that in the short term eunomia can provide consistent
> kubectl/oc client versions in all template processor images. In my
> opinion this means changing the oc client version in the ocp-template
> processor image to version 3.11.x.
>
> I believe long term we want to provide a way to include or use
> multiple kubectl/oc client version. See #220.

**Additionally,** adds a basic test is to ensure template processor can work on minishift.
The script is currently not yet part of CI. In its current state, the
script is very rudimentary. I only wanted to get it to a point, where on
my machine it manages to successfully create a helloworld Pod in
minishift. I assume the script will be improved in future until it gets
to a state where it can be merged into the CI pipeline.

**Type of change**

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)
* Breaking change (fix or feature that would cause existing functionality to not work as expected)

**Checklist**

- [ ] Unit tests and e2e tests updated
- [ ] Documentation updated
