### PR TITLE
deploy: include eunomia-cluster-list clusterrole

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,7 +258,13 @@ Currently the following templating engines are supported (follow the link to see
 
 ## serviceAccountRef
 
-This is the service account used by the job pod that will process the resources. The service account must be present in the same namespace as the one where the GitOpsConfig CR is and must have enough permission to manage the resources. It is out of scope of this controller how that service account is provisioned, although you can use a different GitOpsConfig CR to provision it (seeding CR).
+This is the service account used by the job pod that will process the resources.
+The service account must be present in the same namespace as the one where the GitOpsConfig CR is and must have enough permission to manage the resources.
+It is out of scope of this controller how that service account is provisioned, although you can use a different GitOpsConfig CR to provision it (seeding CR).
+
+In the Helm deployment, the `ClusterRole` `eunomia-cluster-list` provides `list` access to all resources, and will be provisioned if you set `.Values.eunomia.operator.deployment.clusterViewer` to `true`.
+This `ClusterRole` is intended to be used in a `ClusterRoleBinding` with "job runner" service accounts so they can find all of the resources that it owns.
+Without the `ClusterRoleBinding`, the jobs can still successfully run, however there will be error logs stating it can not find any cluster scoped resources.
 
 ## Resource Handling Mode
 

--- a/deploy/helm/eunomia-operator/templates/clusterrole-eunomia-cluster-list.yaml
+++ b/deploy/helm/eunomia-operator/templates/clusterrole-eunomia-cluster-list.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.eunomia.operator.deployment.clusterViewer -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: eunomia-cluster-list
+rules:
+# Allow all actions on gitopsconfigs
+- apiGroups:
+  - '*'
+  resources:
+  - '*'
+  verbs:
+  - list
+- nonResourceURLs:
+  - '*'
+  verbs:
+  - list
+{{- end -}}

--- a/deploy/helm/eunomia-operator/values.yaml
+++ b/deploy/helm/eunomia-operator/values.yaml
@@ -1,9 +1,10 @@
 eunomia:
   operator:
     namespace: "eunomia-operator"
-    deployment: 
+    deployment:
       enabled: true
       nsRbacOnly: false
+      clusterViewer: true
     replicas: 1
     serviceAccount: "eunomia-operator"
 


### PR DESCRIPTION
<!--
    Please read https://github.com/KohlsTechnology/eunomia/blob/master/.github/CONTRIBUTING.md before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

When Eunomia jobs are trying to determine what resources it needs to
delete, it retrieves all kubernetes resource kinds, and uses that list
of kinds to get all resources that meet the "ownership" and the "not
applied in this job" filters.

If the service account the job is running as does not have a ClusterRole
that provides access to list cluster scoped resources, the job will log
`Forbidden` errors for every one of the cluster scoped resource types
which can be confusing to users.

This ClusterRole gives the job quite a bit of access, so in a future
pull request it would make sense to only search in kinds that the
service account has access to manage.

Fixes #240

**Type of change**

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)

**Checklist**

- [ ] ~Unit tests and e2e tests updated~
- [x] Documentation updated
