### PR TITLE
handler: add Ref check to WebhookHandler

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ You can enable one or multiple triggers.
 |:---|:---|
 |`Change` | This triggers every time the CR is changed, including when it is created.|
 |`Periodic` | Periodically apply the configuration. This can be used to either schedule changes for a specific time, use it for drift management to revert any changes, or as a safeguard in case webhooks were missed. It uses a cron-style expression.
-|`Webhook` | This triggers when something on git changes. You have to configure the webhook yourself.
+|`Webhook` | This triggers when something on git changes. You have to configure the webhook yourself. For branches use just branch name in GitOpsConfig CR `ref`, but if you want webhook working for git tag, use refs/tags/[tag_name].
 
 ### GitHub webhook configuration
 

--- a/pkg/handler/handler_test.go
+++ b/pkg/handler/handler_test.go
@@ -1,0 +1,150 @@
+/*
+Copyright 2020 Kohl's Department Stores, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package handler
+
+import (
+	"testing"
+
+	"github.com/google/go-github/github"
+
+	gitopsv1alpha1 "github.com/KohlsTechnology/eunomia/pkg/apis/eunomia/v1alpha1"
+)
+
+func newstring(v string) *string { return &v }
+
+func TestRepoURLAndRefMatch(t *testing.T) {
+
+	defaultGit := gitopsv1alpha1.GitConfig{
+		URI: "https://github.com/kohlstechnology/eunomia",
+		Ref: "master",
+	}
+
+	tests := []struct {
+		comment string
+		spec    gitopsv1alpha1.GitOpsConfigSpec
+		event   github.PushEvent
+		want    bool
+	}{
+		{
+			comment: "full match - branch",
+			spec:    gitopsv1alpha1.GitOpsConfigSpec{TemplateSource: defaultGit, ParameterSource: defaultGit},
+			event: github.PushEvent{
+				Ref: newstring("master"),
+				Repo: &github.PushEventRepository{
+					FullName: newstring("kohlstechnology/eunomia"),
+				},
+			},
+			want: true,
+		},
+		{
+			comment: "full match - git tag",
+			spec: gitopsv1alpha1.GitOpsConfigSpec{
+				TemplateSource: defaultGit,
+				ParameterSource: gitopsv1alpha1.GitConfig{
+					URI: defaultGit.URI,
+					Ref: "refs/tags/0.1.4",
+				},
+			},
+			event: github.PushEvent{
+				Ref: newstring("refs/tags/0.1.4"),
+				Repo: &github.PushEventRepository{
+					FullName: newstring("kohlstechnology/eunomia"),
+				},
+			},
+			want: true,
+		},
+		{
+			comment: "TemplateSource match",
+			spec: gitopsv1alpha1.GitOpsConfigSpec{
+				TemplateSource: defaultGit,
+				ParameterSource: gitopsv1alpha1.GitConfig{
+					URI: defaultGit.URI,
+					Ref: "master2",
+				},
+			},
+			event: github.PushEvent{
+				Ref: newstring("master"),
+				Repo: &github.PushEventRepository{
+					FullName: newstring("kohlstechnology/eunomia"),
+				},
+			},
+			want: true,
+		},
+		{
+			comment: "ParameterSource match",
+			spec: gitopsv1alpha1.GitOpsConfigSpec{
+				TemplateSource: gitopsv1alpha1.GitConfig{
+					URI: defaultGit.URI,
+					Ref: "master2",
+				},
+				ParameterSource: defaultGit,
+			},
+			event: github.PushEvent{
+				Ref: newstring("master"),
+				Repo: &github.PushEventRepository{
+					FullName: newstring("kohlstechnology/eunomia"),
+				},
+			},
+			want: true,
+		},
+		{
+			comment: "Ref differs",
+			spec: gitopsv1alpha1.GitOpsConfigSpec{
+				TemplateSource:  defaultGit,
+				ParameterSource: defaultGit,
+			},
+			event: github.PushEvent{
+				Ref: newstring("refs/tags/0.1.4"),
+				Repo: &github.PushEventRepository{
+					FullName: newstring("kohlstechnology/eunomia"),
+				},
+			},
+			want: false,
+		},
+		{
+			comment: "URI differs",
+			spec:    gitopsv1alpha1.GitOpsConfigSpec{TemplateSource: defaultGit, ParameterSource: defaultGit},
+			event: github.PushEvent{
+				Ref: newstring("master"),
+				Repo: &github.PushEventRepository{
+					FullName: newstring("kohlstechnology/git2consul-go"),
+				},
+			},
+			want: false,
+		},
+		{
+			comment: "URI and Ref differs",
+			spec:    gitopsv1alpha1.GitOpsConfigSpec{TemplateSource: defaultGit, ParameterSource: defaultGit},
+			event: github.PushEvent{
+				Ref: newstring("master2"),
+				Repo: &github.PushEventRepository{
+					FullName: newstring("kohlstechnology/git2consul-go"),
+				},
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		gitops := &gitopsv1alpha1.GitOpsConfig{Spec: tt.spec}
+		pushEvent := &tt.event
+		result := repoURLAndRefMatch(gitops, pushEvent)
+		if result != tt.want {
+			t.Errorf("%q: expected %v, got %v", tt.comment, tt.want, result)
+		}
+	}
+}

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -84,7 +84,7 @@ kubectl apply -f examples/hello-world-yaml/eunomia-runner-sa.yaml -n eunomia-hel
 
 #Test hello-world-yaml-cr1
 hello_world_yaml_cr_1() {
-    timeout=30
+    timeout=60
     kubectl apply -f examples/hello-world-yaml/cr/hello-world-cr1.yaml -n eunomia-hello-world-yaml-demo
     while ((--timeout)) && [[ "$(kubectl get po -n eunomia-hello-world-yaml-demo -l name=hello-world -o=jsonpath="{range .items[*]}{.status.phase}{'\n'}{end}")" != "Running" ]]; do
         echo "waiting for hello-world-yaml-cr1 deployment: remaining $timeout sec..."


### PR DESCRIPTION
<!--
    Please read https://github.com/KohlsTechnology/eunomia/blob/master/.github/CONTRIBUTING.md before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->
GitHub webhook is triggered on all Push events and without checking 
branch in WebhookHandler new job is created every time there is push to 
repo, no matter what branch. In this PR I added check, so job is created 
only when URI and Ref matches in push event and GitOpsConfig CR.

Additionally it's fixing Travis CI that was failing on hello-world-yaml-cr1 test by increasing timeout.

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #252

**Type of change**

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)

**Checklist**

- [x] Unit tests and e2e tests updated
- [x] Documentation updated
