### PR TITLE
Only Run Travis CI Deploy Step Once

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,9 +67,9 @@ jobs:
 stages:
   - test
   - name: deploy
-    if: type IN (push) AND branch = master
+    if: type = push AND branch = master AND fork = false
   - name: deploy-release
-    if: tag =~ /^v\d+\.\d+\.\d+$/
+    if: tag =~ /^v\d+\.\d+\.\d+$/ AND fork = false
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,8 @@ env:
   # NOTE: We can add 200 items to the build matrix, but only 3 run in parallel. So having more than three
   # items in the build matrix will cause the tests to wait in a queue. We will need to select the k8s versions
   # that we want to test carefully, or we risk having the tests run for a very long time.
-  - OPERATOR_SDK_VERSION=v0.8.1 KUBE_VERSION=v1.14.2 MINIKUBE_VERSION=v1.6.2 SHFMT_VERSION=v3.0.1
-  - OPERATOR_SDK_VERSION=v0.8.1 KUBE_VERSION=v1.13.2 MINIKUBE_VERSION=v1.6.2 SHFMT_VERSION=v3.0.1
+  - OPERATOR_SDK_VERSION=v0.8.1 KUBE_VERSION=v1.15.10 MINIKUBE_VERSION=v1.6.2 SHFMT_VERSION=v3.0.1
+  - OPERATOR_SDK_VERSION=v0.8.1 KUBE_VERSION=v1.16.7 MINIKUBE_VERSION=v1.6.2 SHFMT_VERSION=v3.0.1
 
 before_install:
   - travis_retry go mod vendor
@@ -53,19 +53,24 @@ before_script:
 script:
   - make test-dirty test
 
+jobs:
+  include:
+    - stage: deploy
+      env:
+        - OPERATOR_SDK_VERSION=v0.8.1 KUBE_VERSION=v1.15.10 MINIKUBE_VERSION=v1.6.2 SHFMT_VERSION=v3.0.1
+      script: make travis-deploy-images
+    - stage: deploy-release
+      env:
+        - OPERATOR_SDK_VERSION=v0.8.1 KUBE_VERSION=v1.15.10 MINIKUBE_VERSION=v1.6.2 SHFMT_VERSION=v3.0.1
+      script: make travis-release
+
+stages:
+  - test
+  - name: deploy
+    if: type IN (push) AND branch = master
+  - name: deploy-release
+    if: tag =~ /^v\d+\.\d+\.\d+$/
+
 after_success:
   - bash <(curl -s https://codecov.io/bash)
 
-deploy:
-  - provider: script
-    skip_cleanup: true
-    script: make travis-deploy-images
-    on:
-      repo: KohlsTechnology/eunomia
-      branch: master
-  - provider: script
-    skip_cleanup: true
-    script: make travis-release
-    on:
-      repo: KohlsTechnology/eunomia
-      tags: true


### PR DESCRIPTION
<!--
    Please read https://github.com/KohlsTechnology/eunomia/blob/master/.github/CONTRIBUTING.md before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**
When the original build matrix was added to enable testing multiple k8s
versions in Travis CI the deploy would also run for each k8s version in
the build matrix. This changes makes the deploy step only run once.

See below Travis CI docs for details.

https://docs.travis-ci.com/user/build-stages/#build-stages-and-deployments

<!-- Please provide a summary of the change here. -->

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #256 

**Type of change**

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)

**Checklist**

- [x] Unit tests and e2e tests updated
- [ ] Documentation updated
