### PR TITLE
template-processors/base: use fully qualified kind names in kubectl (#273)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,7 @@ shellcheck:
 
 .PHONY: e2e-test-images
 e2e-test-images: build
-	TRAVIS_TAG=v999.0.0 ./scripts/build-images.sh ${REPOSITORY}
+	TRAVIS_TAG=latest ./scripts/build-images.sh ${REPOSITORY}
 
 # Deploy images to Quay.io
 .PHONY: travis-deploy-images

--- a/template-processors/base/bin/resourceManager.sh
+++ b/template-processors/base/bin/resourceManager.sh
@@ -63,9 +63,9 @@ function deleteByOldLabels() {
     local allKinds="$(kube api-resources --verbs=list -o name | grep -ivE '^componentstatus(es)?$' | paste -sd, -)"
     local ownedKinds="$(kube get "$allKinds" --ignore-not-found \
         -l "$TAG_OWNER==$owner" \
-        -o custom-columns=kind:.kind \
-        --no-headers=true |
+        -o jsonpath="{range .items[*]}{.kind} {.apiVersion}{'\n'}{end}" | # e.g. "Pod v1" OR "StorageClass storage.k8s.io/v1"
         sort -u |
+        awk -F'[ /]' '{if (NF==2) {print $1} else {print $1"."$3"."$2}}' | # e.g. "Pod" OR "StorageClass.v1.storage.k8s.io"
         paste -sd, -)"
     if [ -z "$ownedKinds" ]; then
         return

--- a/template-processors/base/bin/resourceManager.sh
+++ b/template-processors/base/bin/resourceManager.sh
@@ -59,8 +59,7 @@ function addLabels() {
 function deleteByOldLabels() {
     local owner="$1"
     local timestamp="${2:-}"
-    # NOTE: removing componentstatus because it shows up unintended in ownedKinds: https://github.com/kubernetes/kubectl/issues/151#issuecomment-562578617
-    local allKinds="$(kube api-resources --verbs=list -o name | grep -ivE '^componentstatus(es)?$' | paste -sd, -)"
+    local allKinds="$(kube api-resources --verbs=list,delete -o name | paste -sd, -)"
     local ownedKinds="$(kube get "$allKinds" --ignore-not-found \
         -l "$TAG_OWNER==$owner" \
         -o jsonpath="{range .items[*]}{.kind} {.apiVersion}{'\n'}{end}" | # e.g. "Pod v1" OR "StorageClass storage.k8s.io/v1"


### PR DESCRIPTION
<!--
    Please read https://github.com/KohlsTechnology/eunomia/blob/master/.github/CONTRIBUTING.md before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

## Description

Before, a list of resource kinds passed to `kubectl delete` was built
based on data from "kind" column of `kubectl get`. However, this showed
up to be bad, as the data was not fully & uniquely identifying for
resource kinds. As a result, reusing them later in `kubectl delete`
resulted in different kinds being targeted than expected.

This commit changes the approach to use jsonpath formatting of `kubectl
get` to extract raw "kind" and "apiVersion" data. This data allows us to
build a unique, fully qualified resource name. Unfortunately, it
requires some extra processing with `awk`, as the format expected by
`kubectl get` differs somewhat from what's present in
"kind"+"apiVersion".

Unfortunately, I didn't manage to find a way to write an automated e2e
test for this fix.

Fixes #273.

Additionally, a fix to #277 & #278 is included in a separate commit.

### Alternatives


The approach chosen in this commit seems to work, but it's not 100%
clear to what extent it will be robust. It relies on "kind" and
"apiVersion" fields returned by resource controllers in response to
"list" requests, however those responses seem to not be 100% guaranteed
to be correct. One alternative approach could then be to run separate
`kubectl get` for each known kind, and if 1+ results were returned,
remember the kind used in the request (vs. response as is done
currently). However, when I tested this approach, it had a *huge* impact
in slowing down script completion time. Because of that, I chose the
simpler and faster approach for now. I believe we should see how it
works in practice, and decide on the slower approach only in case the
current approach shows up to be not enough.


## Type of change

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)
* New feature (non-breaking change which adds functionality)
* Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] Unit tests and e2e tests updated
- [ ] Documentation updated
