### PR TITLE
chore: add minishift to TravisCI test matrix

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "ci"]
+	path = ci
+	url = https://github.com/fabiand/traviskube

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ env:
   # that we want to test carefully, or we risk having the tests run for a very long time.
   - OPERATOR_SDK_VERSION=v0.8.1 KUBE_VERSION=v1.15.10 MINIKUBE_VERSION=v1.6.2 SHFMT_VERSION=v3.0.1
   - OPERATOR_SDK_VERSION=v0.8.1 KUBE_VERSION=v1.16.7 MINIKUBE_VERSION=v1.6.2 SHFMT_VERSION=v3.0.1
+  - OPERATOR_SDK_VERSION=v0.8.1 KUBE_VERSION=v1.11.0 OPENSHIFT_VERSION=3.11.0 SHFMT_VERSION=v3.0.1
 
 before_install:
   - travis_retry go mod vendor
@@ -27,16 +28,23 @@ before_install:
 # Lines use encrypted_18f270609d30_key and encrypted_18f270609d30_iv variables set in Travis settings to decrypt
 # github_deploy_key.enc file into github_deploy_key and then add this key to ssh-agent session. All of this happens only
 # if current build is on repository tag.
-  - if [[ "$TRAVIS_TAG" ]]; then openssl aes-256-cbc -K $encrypted_18f270609d30_key -iv $encrypted_18f270609d30_iv -in github_deploy_key.enc -out github_deploy_key -d; fi
-  - if [[ "$TRAVIS_TAG" ]]; then chmod 600 github_deploy_key; fi
-  - if [[ "$TRAVIS_TAG" ]]; then eval $(ssh-agent -s); fi
-  - if [[ "$TRAVIS_TAG" ]]; then ssh-add github_deploy_key; fi
+  - |
+    if [[ "$TRAVIS_TAG" ]]; then
+      openssl aes-256-cbc -K $encrypted_18f270609d30_key -iv $encrypted_18f270609d30_iv -in github_deploy_key.enc -out github_deploy_key -d
+      chmod 600 github_deploy_key
+      eval $(ssh-agent -s)
+      ssh-add github_deploy_key
+    fi
 
 before_script:
 - curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/${KUBE_VERSION}/bin/linux/amd64/kubectl
 - sudo chmod +x kubectl && sudo mv kubectl /usr/local/bin/
-- curl -Lo minikube https://storage.googleapis.com/minikube/releases/${MINIKUBE_VERSION}/minikube-linux-amd64
-- sudo chmod +x minikube && sudo mv minikube /usr/local/bin/
+- |
+  if [[ "$MINIKUBE_VERSION" ]]; then
+    curl -Lo minikube https://storage.googleapis.com/minikube/releases/${MINIKUBE_VERSION}/minikube-linux-amd64
+    sudo chmod +x minikube
+    sudo mv minikube /usr/local/bin/
+  fi
 - curl -LO https://git.io/get_helm.sh && chmod 700 get_helm.sh && ./get_helm.sh
 - curl -OJL https://github.com/operator-framework/operator-sdk/releases/download/${OPERATOR_SDK_VERSION}/operator-sdk-${OPERATOR_SDK_VERSION}-x86_64-linux-gnu
 - chmod +x operator-sdk-${OPERATOR_SDK_VERSION}-x86_64-linux-gnu
@@ -45,8 +53,14 @@ before_script:
 - rm operator-sdk-${OPERATOR_SDK_VERSION}-x86_64-linux-gnu
 - curl -Lo shfmt https://github.com/mvdan/sh/releases/download/${SHFMT_VERSION}/shfmt_${SHFMT_VERSION}_linux_amd64
 - sudo chmod +x shfmt && sudo mv shfmt /usr/local/bin/
-- sudo minikube start --vm-driver=none --kubernetes-version=${KUBE_VERSION}
-- minikube update-context
+- |
+  if [[ "$MINIKUBE_VERSION" ]]; then
+    sudo minikube start --vm-driver=none --kubernetes-version=${KUBE_VERSION}
+    minikube update-context
+  elif [[ "$OPENSHIFT_VERSION" ]]; then
+    bash -x ci/prepare-host minishift
+    bash -x ci/start-cluster minishift ${OPENSHIFT_VERSION}
+  fi
 - JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'; until kubectl get nodes -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1; done
 
 
@@ -73,4 +87,3 @@ stages:
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)
-


### PR DESCRIPTION
<!--
    Please read https://github.com/KohlsTechnology/eunomia/blob/master/.github/CONTRIBUTING.md before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**
Run the test automation against minishift Openshift cluster, so that we know the operator works with OCP. I needed to add few conditional expressions to make e2e script working with both minikube and minishift. I added traviskube CI submodule to have minishift working in TravisCI.

<!-- Please provide a summary of the change here. -->

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #185 

**Type of change**

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)
* New feature (non-breaking change which adds functionality)

**Checklist**

- [x] Unit tests and e2e tests updated
