### PR TITLE
Delete cronjobs left after Periodic trigger has been removed from GitOpsConfig

### DIFF
--- a/pkg/controller/gitopsconfig/controller.go
+++ b/pkg/controller/gitopsconfig/controller.go
@@ -194,8 +194,22 @@ func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 		if err != nil {
 			reqLogger.Error(err, "error creating the cronjob, continuing...")
 		}
+	} else {
+		// if there are some leftover cronjobs after removing the Periodic trigger, delete them
+		cronJobs, err := ownedCronJobs(context.TODO(), r.client, instance)
+		if err != nil {
+			reqLogger.Error(err, "unable to list cronjobs", "namespace", instance.Namespace)
+			return reconcile.Result{}, xerrors.Errorf("unable to list cronjobs while checking if there are any left after updating GitOpsConfig: %w", err)
+		}
+		for _, cronJob := range cronJobs {
+			err = r.client.Delete(context.TODO(), &cronJob, client.PropagationPolicy(metav1.DeletePropagationBackground))
+			if err != nil {
+				log.Error(err, "Unable to delete leftover cronjob", "instance", instance.Name, "cronjob", cronJob.Name)
+				return reconcile.Result{}, xerrors.Errorf("Unable to delete leftover cronjob %q for %q: %w", cronJob.Name, instance.Name, err)
+			}
+			log.Info("Deleted leftover cronjob", "instance", instance.Name, "cronjob", cronJob.Name)
+		}
 	}
-	// TODO: if Periodic trigger is removed from CR, remove corresponding CronJob
 
 	if ContainsTrigger(instance, "Change") || ContainsTrigger(instance, "Webhook") {
 		reqLogger.Info("Instance has a change or Webhook trigger, creating job", "instance", instance.GetName())

--- a/pkg/controller/gitopsconfig/controller.go
+++ b/pkg/controller/gitopsconfig/controller.go
@@ -414,7 +414,14 @@ func (r *Reconciler) manageDeletion(instance *gitopsv1alpha1.GitOpsConfig) (reco
 		return r.removeFinalizer(context.TODO(), instance)
 	}
 
-	// TODO: also search and delete a CronJob
+	// Note:
+	// CronJob is deleted implicitly, so no need to include deletion here. While
+	// creating a CronJob in the createCronJob function, the SetControllerReference
+	// function makes the GitOpsConfig the owner of the CronJob. If the GitOpsConfig
+	// is deleted, the CronJob is garbage-collected by Kubernetes.
+	// Ref:
+	// https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/controller/controllerutil?tab=doc#SetControllerReference
+	// https://kubernetes.io/docs/concepts/workloads/controllers/garbage-collection/
 
 	// We list all jobs that were created because of this GitOpsConfig. Then,
 	// further down, we will take one of a few different actions depending on

--- a/test/e2e/issue279_test.go
+++ b/test/e2e/issue279_test.go
@@ -1,0 +1,301 @@
+// +build e2e
+
+/*
+Copyright 2020 Kohl's Department Stores, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	framework "github.com/operator-framework/operator-sdk/pkg/test"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	"github.com/KohlsTechnology/eunomia/pkg/apis"
+	gitopsv1alpha1 "github.com/KohlsTechnology/eunomia/pkg/apis/eunomia/v1alpha1"
+	"github.com/KohlsTechnology/eunomia/pkg/util"
+)
+
+// TestIssue279CronJobDeletion verifies that after removing Periodic trigger from
+// GitOpsConfig, CronJob gets also deleted
+func TestIssue279CronJobDeletion(t *testing.T) {
+	ctx := framework.NewTestCtx(t)
+	defer ctx.Cleanup()
+
+	namespace, err := ctx.GetNamespace()
+	if err != nil {
+		t.Fatalf("could not get namespace: %v", err)
+	}
+	if err = SetupRbacInNamespace(namespace); err != nil {
+		t.Error(err)
+	}
+
+	defer DumpJobsLogsOnError(t, framework.Global, namespace)
+	err = framework.AddToFrameworkScheme(apis.AddToScheme, &gitopsv1alpha1.GitOpsConfigList{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	eunomiaURI, found := os.LookupEnv("EUNOMIA_URI")
+	if !found {
+		eunomiaURI = "https://github.com/kohlstechnology/eunomia"
+	}
+	eunomiaRef, found := os.LookupEnv("EUNOMIA_REF")
+	if !found {
+		eunomiaRef = "master"
+	}
+
+	// Step 1: create a CR with a Periodic trigger
+
+	gitops := &gitopsv1alpha1.GitOpsConfig{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "GitOpsConfig",
+			APIVersion: "eunomia.kohls.io/v1alpha1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "gitops-issue279",
+			Namespace: namespace,
+			Finalizers: []string{
+				"gitopsconfig.eunomia.kohls.io/finalizer",
+			},
+		},
+		Spec: gitopsv1alpha1.GitOpsConfigSpec{
+			TemplateSource: gitopsv1alpha1.GitConfig{
+				URI:        eunomiaURI,
+				Ref:        eunomiaRef,
+				ContextDir: "test/e2e/testdata/empty-directory",
+			},
+			ParameterSource: gitopsv1alpha1.GitConfig{
+				URI:        eunomiaURI,
+				Ref:        eunomiaRef,
+				ContextDir: "test/e2e/testdata/empty-yaml",
+			},
+			Triggers: []gitopsv1alpha1.GitOpsTrigger{
+				{
+					Type: "Periodic",
+					Cron: "*/1 * * * *",
+				},
+			},
+			TemplateProcessorImage: "quay.io/kohlstechnology/eunomia-base:dev",
+			ResourceHandlingMode:   "Apply",
+			ResourceDeletionMode:   "Delete",
+			ServiceAccountRef:      "eunomia-operator",
+		},
+	}
+	gitops.Annotations = map[string]string{"gitopsconfig.eunomia.kohls.io/initialized": "true"}
+
+	err = framework.Global.Client.Create(context.TODO(), gitops, &framework.CleanupOptions{TestContext: ctx, Timeout: timeout, RetryInterval: retryInterval})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Step 2: Wait until CronJob creates a Job, whose pod succeeds
+
+	// Two minutes timeout to give cronjob enought time to kick off
+	err = wait.Poll(retryInterval, time.Second*120, func() (done bool, err error) {
+		const name = "gitopsconfig-gitops-issue279-"
+		pod, err := GetPod(namespace, name, "quay.io/kohlstechnology/eunomia-base:dev", framework.Global.KubeClient)
+		switch {
+		case apierrors.IsNotFound(err):
+			t.Logf("Waiting for availability of %s pod", name)
+			return false, nil
+		case err != nil:
+			return false, err
+		case pod != nil && pod.Status.Phase == "Succeeded":
+			return true, nil
+		case pod != nil:
+			t.Logf("Waiting for pod %s to succeed", pod.Name)
+			return false, nil
+		default:
+			t.Logf("Waiting for pod %s", name)
+			return false, nil
+		}
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Step 3: Change Periodic trigger to Webhook one in GitOpsConfig, and apply it
+
+	err = framework.Global.Client.Get(context.TODO(), util.NN{Name: "gitops-issue279", Namespace: namespace}, gitops)
+	if err != nil {
+		t.Fatal(err)
+	}
+	gitops.Spec.Triggers = []gitopsv1alpha1.GitOpsTrigger{{Type: "Webhook"}}
+	err = framework.Global.Client.Update(context.TODO(), gitops)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("GitOpsConfig successfully updated")
+
+	// Step 4: Wait for CronJob to be deleted
+
+	err = wait.Poll(retryInterval, timeout, func() (done bool, err error) {
+		const name = "gitopsconfig-gitops-issue279-"
+		cronJob, err := GetCronJob(namespace, name, framework.Global.KubeClient)
+		switch {
+		case apierrors.IsNotFound(err) || cronJob == nil:
+			t.Logf("CronJob %s successfully deleted", name)
+			return true, nil
+		case err != nil:
+			return false, err
+		case cronJob != nil:
+			t.Logf("Waiting for cronJob %s to be deleted", cronJob.Name)
+			return false, nil
+		default:
+			t.Logf("Waiting for cronJob %s to be deleted", name)
+			return false, nil
+		}
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+}
+
+// TestIssue279CRWithPeriodicDeletion verifies that after removing GitOpsConfig
+// with Periodic trigger, CronJob also gets deleted
+func TestIssue279CRWithPeriodicDeletion(t *testing.T) {
+	ctx := framework.NewTestCtx(t)
+	defer ctx.Cleanup()
+
+	namespace, err := ctx.GetNamespace()
+	if err != nil {
+		t.Fatalf("could not get namespace: %v", err)
+	}
+	if err = SetupRbacInNamespace(namespace); err != nil {
+		t.Error(err)
+	}
+
+	defer DumpJobsLogsOnError(t, framework.Global, namespace)
+	err = framework.AddToFrameworkScheme(apis.AddToScheme, &gitopsv1alpha1.GitOpsConfigList{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	eunomiaURI, found := os.LookupEnv("EUNOMIA_URI")
+	if !found {
+		eunomiaURI = "https://github.com/kohlstechnology/eunomia"
+	}
+	eunomiaRef, found := os.LookupEnv("EUNOMIA_REF")
+	if !found {
+		eunomiaRef = "master"
+	}
+
+	// Step 1: create a CR with a Periodic trigger
+
+	gitops := &gitopsv1alpha1.GitOpsConfig{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "GitOpsConfig",
+			APIVersion: "eunomia.kohls.io/v1alpha1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "gitops-issue279",
+			Namespace: namespace,
+			Finalizers: []string{
+				"gitopsconfig.eunomia.kohls.io/finalizer",
+			},
+		},
+		Spec: gitopsv1alpha1.GitOpsConfigSpec{
+			TemplateSource: gitopsv1alpha1.GitConfig{
+				URI:        eunomiaURI,
+				Ref:        eunomiaRef,
+				ContextDir: "test/e2e/testdata/empty-directory",
+			},
+			ParameterSource: gitopsv1alpha1.GitConfig{
+				URI:        eunomiaURI,
+				Ref:        eunomiaRef,
+				ContextDir: "test/e2e/testdata/empty-yaml",
+			},
+			Triggers: []gitopsv1alpha1.GitOpsTrigger{
+				{
+					Type: "Periodic",
+					Cron: "*/1 * * * *",
+				},
+			},
+			TemplateProcessorImage: "quay.io/kohlstechnology/eunomia-base:dev",
+			ResourceHandlingMode:   "Apply",
+			ResourceDeletionMode:   "Delete",
+			ServiceAccountRef:      "eunomia-operator",
+		},
+	}
+	gitops.Annotations = map[string]string{"gitopsconfig.eunomia.kohls.io/initialized": "true"}
+
+	err = framework.Global.Client.Create(context.TODO(), gitops, &framework.CleanupOptions{TestContext: ctx, Timeout: timeout, RetryInterval: retryInterval})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Step 2: Make sure that CronJob has been created
+
+	err = wait.Poll(retryInterval, timeout, func() (done bool, err error) {
+		const name = "gitopsconfig-gitops-issue279"
+		cronJob, err := GetCronJob(namespace, name, framework.Global.KubeClient)
+		switch {
+		case apierrors.IsNotFound(err):
+			t.Logf("Wait for availability of cronjob %s", name)
+			return false, nil
+		case err != nil:
+			return false, err
+		case cronJob != nil:
+			t.Logf("Cronjob %s succesfully created", cronJob.Name)
+			return true, nil
+		default:
+			t.Logf("Waiting for cronJob %s", name)
+			return false, nil
+		}
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Step 3: Delete GitOpsConfig and make sure that the deletion succeeded
+
+	t.Logf("Deleting CR")
+	err = framework.Global.Client.Delete(context.TODO(), gitops)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Step 4: Wait for CronJob to be deleted
+
+	err = wait.Poll(retryInterval, timeout, func() (done bool, err error) {
+		const name = "gitopsconfig-gitops-issue279"
+		cronJob, err := GetCronJob(namespace, name, framework.Global.KubeClient)
+		switch {
+		case apierrors.IsNotFound(err) || cronJob == nil:
+			t.Logf("CronJob %s successfully deleted", name)
+			return true, nil
+		case err != nil:
+			return false, err
+		case cronJob != nil:
+			t.Logf("Waiting for cronJob %s to be deleted", cronJob.Name)
+			return false, nil
+		default:
+			t.Logf("Waiting for cronJob %s to be deleted", name)
+			return false, nil
+		}
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+}

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -34,6 +34,7 @@ import (
 	"github.com/KohlsTechnology/eunomia/pkg/util"
 	framework "github.com/operator-framework/operator-sdk/pkg/test"
 	"golang.org/x/xerrors"
+	batchv1beta1 "k8s.io/api/batch/v1beta1"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -159,6 +160,21 @@ func WaitForPodAbsence(t *testing.T, f *framework.Framework, namespace, name, im
 	}
 	t.Logf("pod %s in namespace %s is absent", name, namespace)
 	return nil
+}
+
+// GetCronJob retrieves a given cronJob based on namespace, and the cronJob name prefix
+func GetCronJob(namespace, namePrefix string, kubeclient kubernetes.Interface) (*batchv1beta1.CronJob, error) {
+	cronJobs, err := kubeclient.BatchV1beta1().CronJobs(namespace).List(metav1.ListOptions{})
+	if err != nil {
+		return nil, xerrors.Errorf("cannot retrieve cronjobs in namespace %q: %w", namespace, err)
+	}
+	for _, cronJob := range cronJobs.Items {
+		if strings.HasPrefix(cronJob.Name, namePrefix) {
+			fmt.Printf("Found cronjob %s\n", cronJob.Name)
+			return &cronJob, nil
+		}
+	}
+	return nil, nil
 }
 
 // DumpJobsLogsOnError checks if t is marked as failed, and if yes, dumps the logs of all pods in the specified namespace.


### PR DESCRIPTION
<!--
    Please read https://github.com/KohlsTechnology/eunomia/blob/master/.github/CONTRIBUTING.md before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->
Delete cronjobs left after GitOpsConfig with Periodic trigger has been
updated to not have such trigger. Now if GitOpsConfig gets updated, and
does not contain Periodic trigger, list cronjobs owned by GitOpsConfig
in reconciliation loop, and delete them.

Add note on how cronjob owned by GitOpsConfig is deleted after
GitOpsConfig has been deleted. It is managed by k8s. Do not handle
cronjob deletion explicitly as it cannot block the creation of a
GitOpsConfig delete job.

ALSO:
Handle situation when there is more than one stuck job. Such situation
can occur when there is a Periodic trigger in a GitOpsConfig which has
wrong image specified.
Previously, if there were more than one stuck job, finalizer wouldn't've
removed them.

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #279 

**Type of change**

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)

**Checklist**

- [x] Unit tests and e2e tests updated
- [ ] Documentation updated (not needed in this PR)
