### PR TITLE
chore: disable codecov "fail" markers (#316)

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,8 @@
+coverage:
+  status:
+    # Disable CI "fail" statuses because of unmet coverage targets - we don't
+    # currently consider them wanted/valuable (see also #316)
+    # https://docs.codecov.io/docs/commit-status#section-disabling-a-status
+    project: off
+    patch: off
+


### PR DESCRIPTION


<!--
    Please read https://github.com/KohlsTechnology/eunomia/blob/master/.github/CONTRIBUTING.md before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

A quick attempt at fixing #316 

<!-- Please provide a summary of the change here. -->
We don't want commits/PRs to be marked as "failed" because of unmet code
coverage targets. We don't currently see this as a valuable check for
PRs, and don't want it to introduce noise and unneeded obstacles in PR
process.

Fixes #316 (hopefully)

**Type of change**

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)
* New feature (non-breaking change which adds functionality)
* Breaking change (fix or feature that would cause existing functionality to not work as expected)

**Checklist**

- [ ] Unit tests and e2e tests updated
- [ ] Documentation updated
