### PR TITLE
tests/e2e: refactor common preamble into separate function

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ check-shfmt:
 # get_helm.sh is ignored because it is getting download from internet
 .PHONY: shellcheck
 shellcheck:
-	for file in $(shell find . -not -path "./vendor/*" -not -path "./get_helm.sh" -name "*.sh") ; do shellcheck $$file ; done
+	shellcheck $(shell find . -not -path "./vendor/*" -not -path "./get_helm.sh" -not -path "./ci/*" -name "*.sh")
 
 .PHONY: e2e-test-images
 e2e-test-images: build

--- a/template-processors/base/bin/gitClone.sh
+++ b/template-processors/base/bin/gitClone.sh
@@ -38,7 +38,7 @@ function pullFromTemplatesRepo() {
         export http_proxy
         export https_proxy
         export no_proxy
-        git clone -b "$TEMPLATE_GIT_REF" "$TEMPLATE_GIT_URI" "$TEMPLATE_GIT_DIR"
+        git clone --depth 1 --shallow-submodules -b "$TEMPLATE_GIT_REF" "$TEMPLATE_GIT_URI" "$TEMPLATE_GIT_DIR"
     )
 }
 
@@ -64,7 +64,7 @@ function pullFromParametersRepo() {
         export http_proxy
         export https_proxy
         export no_proxy
-        git clone -b "$PARAMETER_GIT_REF" "$PARAMETER_GIT_URI" "$PARAMETER_GIT_DIR"
+        git clone --depth 1 --shallow-submodules -b "$PARAMETER_GIT_REF" "$PARAMETER_GIT_URI" "$PARAMETER_GIT_DIR"
     )
 }
 

--- a/test/e2e/context.go
+++ b/test/e2e/context.go
@@ -1,0 +1,72 @@
+// +build e2e
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	framework "github.com/operator-framework/operator-sdk/pkg/test"
+
+	"github.com/KohlsTechnology/eunomia/pkg/apis"
+	gitopsv1alpha1 "github.com/KohlsTechnology/eunomia/pkg/apis/eunomia/v1alpha1"
+)
+
+// Context contains various data commonly used in e2e tests. The struct also
+// embeds and implements context.Context interface.
+type Context struct {
+	context.Context
+	*framework.TestCtx
+	namespace              string
+	eunomiaURI, eunomiaRef string
+}
+
+// NewContext creates a new Context object with all fields filled with values
+// appropriate for the current test function. It is expected that the following
+// preamble will be used at the beginning of typical e2e test functions:
+//
+//	ctx, err := NewContext(t)
+//	if err != nil {
+//		t.Fatal(err)
+//	}
+//	defer ctx.Cleanup()
+func NewContext(t *testing.T) (*Context, error) {
+	testCtx := framework.NewTestCtx(t)
+	ns, err := testCtx.GetNamespace()
+	if err != nil {
+		return nil, fmt.Errorf("e2e new test context: getting namespace: %w", err)
+	}
+	err = SetupRbacInNamespace(ns)
+	if err != nil {
+		return nil, fmt.Errorf("e2e new test context: setting up RBAC: %w", err)
+	}
+
+	err = framework.AddToFrameworkScheme(apis.AddToScheme, &gitopsv1alpha1.GitOpsConfigList{})
+	if err != nil {
+		return nil, fmt.Errorf("e2e new test context: setting up GitOpsConfig scheme: %w", err)
+	}
+
+	eunomiaURI, found := os.LookupEnv("EUNOMIA_URI")
+	if !found {
+		eunomiaURI = "https://github.com/kohlstechnology/eunomia"
+	}
+	eunomiaRef, found := os.LookupEnv("EUNOMIA_REF")
+	if !found {
+		eunomiaRef = "master"
+	}
+
+	testCtx.AddCleanupFn(func() error {
+		DumpJobsLogsOnError(t, framework.Global, ns)
+		return nil
+	})
+
+	return &Context{
+		Context:    context.Background(),
+		TestCtx:    testCtx,
+		namespace:  ns,
+		eunomiaURI: eunomiaURI,
+		eunomiaRef: eunomiaRef,
+	}, nil
+}

--- a/test/e2e/events_test.go
+++ b/test/e2e/events_test.go
@@ -19,8 +19,6 @@ limitations under the License.
 package e2e
 
 import (
-	"context"
-	"os"
 	"testing"
 	"time"
 
@@ -28,7 +26,6 @@ import (
 	eventv1beta1 "k8s.io/api/events/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/KohlsTechnology/eunomia/pkg/apis"
 	gitopsv1alpha1 "github.com/KohlsTechnology/eunomia/pkg/apis/eunomia/v1alpha1"
 	"github.com/KohlsTechnology/eunomia/test"
 )
@@ -36,36 +33,16 @@ import (
 // TestJobEvents_JobSuccess verifies that a JobSucceeded event is emitted by
 // eunomia after a simple GitOpsConfig is executed.
 func TestJobEventsJobSuccess(t *testing.T) {
-	ctx := framework.NewTestCtx(t)
-	defer ctx.Cleanup()
-
-	namespace, err := ctx.GetNamespace()
-	if err != nil {
-		t.Fatalf("could not get namespace: %v", err)
-	}
-	if err = SetupRbacInNamespace(namespace); err != nil {
-		t.Error(err)
-	}
-
-	defer DumpJobsLogsOnError(t, framework.Global, namespace)
-	err = framework.AddToFrameworkScheme(apis.AddToScheme, &gitopsv1alpha1.GitOpsConfigList{})
+	ctx, err := NewContext(t)
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	eunomiaURI, found := os.LookupEnv("EUNOMIA_URI")
-	if !found {
-		eunomiaURI = "https://github.com/kohlstechnology/eunomia"
-	}
-	eunomiaRef, found := os.LookupEnv("EUNOMIA_REF")
-	if !found {
-		eunomiaRef = "master"
-	}
+	defer ctx.Cleanup()
 
 	// Step 1: register an event monitor/watcher
 
 	events := make(chan *eventv1beta1.Event, 5)
-	closer, err := test.WatchEvents(framework.Global.KubeClient, events, namespace, "gitops-events-hello-success", 2*time.Minute)
+	closer, err := test.WatchEvents(framework.Global.KubeClient, events, ctx.namespace, "gitops-events-hello-success", 2*time.Minute)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -80,17 +57,17 @@ func TestJobEventsJobSuccess(t *testing.T) {
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "gitops-events-hello-success",
-			Namespace: namespace,
+			Namespace: ctx.namespace,
 		},
 		Spec: gitopsv1alpha1.GitOpsConfigSpec{
 			TemplateSource: gitopsv1alpha1.GitConfig{
-				URI:        eunomiaURI,
-				Ref:        eunomiaRef,
+				URI:        ctx.eunomiaURI,
+				Ref:        ctx.eunomiaRef,
 				ContextDir: "test/e2e/testdata/events/test-a",
 			},
 			ParameterSource: gitopsv1alpha1.GitConfig{
-				URI:        eunomiaURI,
-				Ref:        eunomiaRef,
+				URI:        ctx.eunomiaURI,
+				Ref:        ctx.eunomiaRef,
 				ContextDir: "test/e2e/testdata/empty-yaml",
 			},
 			Triggers: []gitopsv1alpha1.GitOpsTrigger{
@@ -104,12 +81,12 @@ func TestJobEventsJobSuccess(t *testing.T) {
 	}
 	gitops.Annotations = map[string]string{"gitopsconfig.eunomia.kohls.io/initialized": "true"}
 
-	err = framework.Global.Client.Create(context.TODO(), gitops, &framework.CleanupOptions{TestContext: ctx, Timeout: timeout, RetryInterval: retryInterval})
+	err = framework.Global.Client.Create(ctx, gitops, &framework.CleanupOptions{TestContext: ctx.TestCtx, Timeout: timeout, RetryInterval: retryInterval})
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	err = WaitForPodWithImage(t, framework.Global, namespace, "hello-events-test-a", "hello-app:1.0", retryInterval, timeout)
+	err = WaitForPodWithImage(t, framework.Global, ctx.namespace, "hello-events-test-a", "hello-app:1.0", retryInterval, timeout)
 	if err != nil {
 		t.Error(err)
 	}
@@ -138,36 +115,16 @@ func TestJobEventsJobSuccess(t *testing.T) {
 // TestJobEvents_PeriodicJobSuccess verifies that a JobSuccessful event is
 // emitted by eunomia for a Periodic GitOpsConfig.
 func TestJobEventsPeriodicJobSuccess(t *testing.T) {
-	ctx := framework.NewTestCtx(t)
-	defer ctx.Cleanup()
-
-	namespace, err := ctx.GetNamespace()
-	if err != nil {
-		t.Fatalf("could not get namespace: %v", err)
-	}
-	if err = SetupRbacInNamespace(namespace); err != nil {
-		t.Error(err)
-	}
-
-	defer DumpJobsLogsOnError(t, framework.Global, namespace)
-	err = framework.AddToFrameworkScheme(apis.AddToScheme, &gitopsv1alpha1.GitOpsConfigList{})
+	ctx, err := NewContext(t)
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	eunomiaURI, found := os.LookupEnv("EUNOMIA_URI")
-	if !found {
-		eunomiaURI = "https://github.com/kohlstechnology/eunomia"
-	}
-	eunomiaRef, found := os.LookupEnv("EUNOMIA_REF")
-	if !found {
-		eunomiaRef = "master"
-	}
+	defer ctx.Cleanup()
 
 	// Step 1: register an event monitor/watcher
 
 	events := make(chan *eventv1beta1.Event, 5)
-	closer, err := test.WatchEvents(framework.Global.KubeClient, events, namespace, "gitops-events-periodic-success", 180*time.Second)
+	closer, err := test.WatchEvents(framework.Global.KubeClient, events, ctx.namespace, "gitops-events-periodic-success", 180*time.Second)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -182,17 +139,17 @@ func TestJobEventsPeriodicJobSuccess(t *testing.T) {
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "gitops-events-periodic-success",
-			Namespace: namespace,
+			Namespace: ctx.namespace,
 		},
 		Spec: gitopsv1alpha1.GitOpsConfigSpec{
 			TemplateSource: gitopsv1alpha1.GitConfig{
-				URI:        eunomiaURI,
-				Ref:        eunomiaRef,
+				URI:        ctx.eunomiaURI,
+				Ref:        ctx.eunomiaRef,
 				ContextDir: "test/e2e/testdata/events/test-b",
 			},
 			ParameterSource: gitopsv1alpha1.GitConfig{
-				URI:        eunomiaURI,
-				Ref:        eunomiaRef,
+				URI:        ctx.eunomiaURI,
+				Ref:        ctx.eunomiaRef,
 				ContextDir: "test/e2e/testdata/empty-yaml",
 			},
 			Triggers: []gitopsv1alpha1.GitOpsTrigger{
@@ -209,12 +166,12 @@ func TestJobEventsPeriodicJobSuccess(t *testing.T) {
 	}
 	gitops.Annotations = map[string]string{"gitopsconfig.eunomia.kohls.io/initialized": "true"}
 
-	err = framework.Global.Client.Create(context.TODO(), gitops, &framework.CleanupOptions{TestContext: ctx, Timeout: timeout, RetryInterval: retryInterval})
+	err = framework.Global.Client.Create(ctx, gitops, &framework.CleanupOptions{TestContext: ctx.TestCtx, Timeout: timeout, RetryInterval: retryInterval})
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	err = WaitForPodWithImage(t, framework.Global, namespace, "hello-events-test-b", "hello-app:1.0", retryInterval, 2*time.Minute)
+	err = WaitForPodWithImage(t, framework.Global, ctx.namespace, "hello-events-test-b", "hello-app:1.0", retryInterval, 2*time.Minute)
 	if err != nil {
 		t.Error(err)
 	}
@@ -247,36 +204,16 @@ func TestJobEventsJobFailed(t *testing.T) {
 		t.Skip("This test currently takes minutes to run, because of exponential backoff in kubernetes")
 	}
 
-	ctx := framework.NewTestCtx(t)
-	defer ctx.Cleanup()
-
-	namespace, err := ctx.GetNamespace()
-	if err != nil {
-		t.Fatalf("could not get namespace: %v", err)
-	}
-	if err = SetupRbacInNamespace(namespace); err != nil {
-		t.Error(err)
-	}
-
-	defer DumpJobsLogsOnError(t, framework.Global, namespace)
-	err = framework.AddToFrameworkScheme(apis.AddToScheme, &gitopsv1alpha1.GitOpsConfigList{})
+	ctx, err := NewContext(t)
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	eunomiaURI, found := os.LookupEnv("EUNOMIA_URI")
-	if !found {
-		eunomiaURI = "https://github.com/kohlstechnology/eunomia"
-	}
-	eunomiaRef, found := os.LookupEnv("EUNOMIA_REF")
-	if !found {
-		eunomiaRef = "master"
-	}
+	defer ctx.Cleanup()
 
 	// Step 1: register an event monitor/watcher
 
 	events := make(chan *eventv1beta1.Event, 5)
-	closer, err := test.WatchEvents(framework.Global.KubeClient, events, namespace, "gitops-events-hello-failed", 5*time.Minute)
+	closer, err := test.WatchEvents(framework.Global.KubeClient, events, ctx.namespace, "gitops-events-hello-failed", 5*time.Minute)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -291,17 +228,17 @@ func TestJobEventsJobFailed(t *testing.T) {
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "gitops-events-hello-failed",
-			Namespace: namespace,
+			Namespace: ctx.namespace,
 		},
 		Spec: gitopsv1alpha1.GitOpsConfigSpec{
 			TemplateSource: gitopsv1alpha1.GitConfig{
 				URI:        "https://INVALID!!!",
-				Ref:        eunomiaRef,
+				Ref:        ctx.eunomiaRef,
 				ContextDir: "URI is already invalid so this value should be irrelevant",
 			},
 			ParameterSource: gitopsv1alpha1.GitConfig{
-				URI:        eunomiaURI,
-				Ref:        eunomiaRef,
+				URI:        ctx.eunomiaURI,
+				Ref:        ctx.eunomiaRef,
 				ContextDir: "test/e2e/testdata/empty-yaml",
 			},
 			Triggers: []gitopsv1alpha1.GitOpsTrigger{
@@ -315,7 +252,7 @@ func TestJobEventsJobFailed(t *testing.T) {
 	}
 	gitops.Annotations = map[string]string{"gitopsconfig.eunomia.kohls.io/initialized": "true"}
 
-	err = framework.Global.Client.Create(context.TODO(), gitops, &framework.CleanupOptions{TestContext: ctx, Timeout: timeout, RetryInterval: retryInterval})
+	err = framework.Global.Client.Create(ctx, gitops, &framework.CleanupOptions{TestContext: ctx.TestCtx, Timeout: timeout, RetryInterval: retryInterval})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/e2e/helm_template_test.go
+++ b/test/e2e/helm_template_test.go
@@ -19,43 +19,20 @@ limitations under the License.
 package e2e
 
 import (
-	goctx "context"
-	"os"
 	"testing"
 
 	framework "github.com/operator-framework/operator-sdk/pkg/test"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/KohlsTechnology/eunomia/pkg/apis"
 	gitopsv1alpha1 "github.com/KohlsTechnology/eunomia/pkg/apis/eunomia/v1alpha1"
 )
 
 func TestHelmTemplate(t *testing.T) {
-	ctx := framework.NewTestCtx(t)
-	defer ctx.Cleanup()
-
-	namespace, err := ctx.GetNamespace()
-	if err != nil {
-		t.Fatalf("could not get namespace: %v", err)
-	}
-	if err = SetupRbacInNamespace(namespace); err != nil {
-		t.Error(err)
-	}
-
-	err = framework.AddToFrameworkScheme(apis.AddToScheme, &gitopsv1alpha1.GitOpsConfigList{})
+	ctx, err := NewContext(t)
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	eunomiaURI, found := os.LookupEnv("EUNOMIA_URI")
-	if !found {
-		eunomiaURI = "https://github.com/kohlstechnology/eunomia"
-	}
-
-	eunomiaRef, found := os.LookupEnv("EUNOMIA_REF")
-	if !found {
-		eunomiaRef = "master"
-	}
+	defer ctx.Cleanup()
 
 	gitops := &gitopsv1alpha1.GitOpsConfig{
 		TypeMeta: metav1.TypeMeta{
@@ -64,18 +41,18 @@ func TestHelmTemplate(t *testing.T) {
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "gitops-helm",
-			Namespace: namespace,
+			Namespace: ctx.namespace,
 		},
 		Spec: gitopsv1alpha1.GitOpsConfigSpec{
-			TemplateProcessorArgs: "--set namespace=" + namespace,
+			TemplateProcessorArgs: "--set namespace=" + ctx.namespace,
 			TemplateSource: gitopsv1alpha1.GitConfig{
-				URI:        eunomiaURI,
-				Ref:        eunomiaRef,
+				URI:        ctx.eunomiaURI,
+				Ref:        ctx.eunomiaRef,
 				ContextDir: "test/e2e/testdata/helm/templates",
 			},
 			ParameterSource: gitopsv1alpha1.GitConfig{
-				URI:        eunomiaURI,
-				Ref:        eunomiaRef,
+				URI:        ctx.eunomiaURI,
+				Ref:        ctx.eunomiaRef,
 				ContextDir: "test/e2e/testdata/helm/parameters",
 			},
 			Triggers: []gitopsv1alpha1.GitOpsTrigger{
@@ -89,12 +66,12 @@ func TestHelmTemplate(t *testing.T) {
 	}
 	gitops.Annotations = map[string]string{"gitopsconfig.eunomia.kohls.io/initialized": "true"}
 
-	err = framework.Global.Client.Create(goctx.TODO(), gitops, &framework.CleanupOptions{TestContext: ctx, Timeout: timeout, RetryInterval: retryInterval})
+	err = framework.Global.Client.Create(ctx, gitops, &framework.CleanupOptions{TestContext: ctx.TestCtx, Timeout: timeout, RetryInterval: retryInterval})
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	err = WaitForPodWithImage(t, framework.Global, namespace, "hello-world-helm", "hello-app:1.0", retryInterval, timeout)
+	err = WaitForPodWithImage(t, framework.Global, ctx.namespace, "hello-world-helm", "hello-app:1.0", retryInterval, timeout)
 	if err != nil {
 		t.Error(err)
 	}

--- a/test/e2e/hierarchy_test.go
+++ b/test/e2e/hierarchy_test.go
@@ -19,43 +19,20 @@ limitations under the License.
 package e2e
 
 import (
-	goctx "context"
-	"os"
 	"testing"
 
 	framework "github.com/operator-framework/operator-sdk/pkg/test"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/KohlsTechnology/eunomia/pkg/apis"
 	gitopsv1alpha1 "github.com/KohlsTechnology/eunomia/pkg/apis/eunomia/v1alpha1"
 )
 
 func TestHierarchy(t *testing.T) {
-	ctx := framework.NewTestCtx(t)
-	defer ctx.Cleanup()
-
-	namespace, err := ctx.GetNamespace()
-	if err != nil {
-		t.Fatalf("could not get namespace: %v", err)
-	}
-	if err = SetupRbacInNamespace(namespace); err != nil {
-		t.Error(err)
-	}
-
-	err = framework.AddToFrameworkScheme(apis.AddToScheme, &gitopsv1alpha1.GitOpsConfigList{})
+	ctx, err := NewContext(t)
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	eunomiaURI, found := os.LookupEnv("EUNOMIA_URI")
-	if !found {
-		eunomiaURI = "https://github.com/kohlstechnology/eunomia"
-	}
-
-	eunomiaRef, found := os.LookupEnv("EUNOMIA_REF")
-	if !found {
-		eunomiaRef = "master"
-	}
+	defer ctx.Cleanup()
 
 	gitops := &gitopsv1alpha1.GitOpsConfig{
 		TypeMeta: metav1.TypeMeta{
@@ -64,18 +41,18 @@ func TestHierarchy(t *testing.T) {
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "gitops-hierarchy",
-			Namespace: namespace,
+			Namespace: ctx.namespace,
 		},
 		Spec: gitopsv1alpha1.GitOpsConfigSpec{
-			TemplateProcessorArgs: "--set namespace=" + namespace,
+			TemplateProcessorArgs: "--set namespace=" + ctx.namespace,
 			TemplateSource: gitopsv1alpha1.GitConfig{
-				URI:        eunomiaURI,
-				Ref:        eunomiaRef,
+				URI:        ctx.eunomiaURI,
+				Ref:        ctx.eunomiaRef,
 				ContextDir: "test/e2e/testdata/helm/templates",
 			},
 			ParameterSource: gitopsv1alpha1.GitConfig{
-				URI:        eunomiaURI,
-				Ref:        eunomiaRef,
+				URI:        ctx.eunomiaURI,
+				Ref:        ctx.eunomiaRef,
 				ContextDir: "test/e2e/testdata/hierarchy/level4",
 			},
 			Triggers: []gitopsv1alpha1.GitOpsTrigger{
@@ -89,12 +66,12 @@ func TestHierarchy(t *testing.T) {
 	}
 	gitops.Annotations = map[string]string{"gitopsconfig.eunomia.kohls.io/initialized": "true"}
 
-	err = framework.Global.Client.Create(goctx.TODO(), gitops, &framework.CleanupOptions{TestContext: ctx, Timeout: timeout, RetryInterval: retryInterval})
+	err = framework.Global.Client.Create(ctx, gitops, &framework.CleanupOptions{TestContext: ctx.TestCtx, Timeout: timeout, RetryInterval: retryInterval})
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	err = WaitForPodWithImage(t, framework.Global, namespace, "hello-world-hierarchy", "hello-app:1.0", retryInterval, timeout)
+	err = WaitForPodWithImage(t, framework.Global, ctx.namespace, "hello-world-hierarchy", "hello-app:1.0", retryInterval, timeout)
 	if err != nil {
 		t.Error(err)
 	}

--- a/test/e2e/issue24_test.go
+++ b/test/e2e/issue24_test.go
@@ -19,46 +19,22 @@ limitations under the License.
 package e2e
 
 import (
-	"context"
-	"os"
 	"testing"
 
 	framework "github.com/operator-framework/operator-sdk/pkg/test"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/retry"
 
-	"github.com/KohlsTechnology/eunomia/pkg/apis"
 	gitopsv1alpha1 "github.com/KohlsTechnology/eunomia/pkg/apis/eunomia/v1alpha1"
 	"github.com/KohlsTechnology/eunomia/pkg/util"
 )
 
 func TestIssue24RemovedResourceGetsDeleted(t *testing.T) {
-	ctx := framework.NewTestCtx(t)
-	defer ctx.Cleanup()
-
-	namespace, err := ctx.GetNamespace()
-	if err != nil {
-		t.Fatalf("could not get namespace: %v", err)
-	}
-	if err = SetupRbacInNamespace(namespace); err != nil {
-		t.Error(err)
-	}
-
-	defer DumpJobsLogsOnError(t, framework.Global, namespace)
-	err = framework.AddToFrameworkScheme(apis.AddToScheme, &gitopsv1alpha1.GitOpsConfigList{})
+	ctx, err := NewContext(t)
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	eunomiaURI, found := os.LookupEnv("EUNOMIA_URI")
-	if !found {
-		eunomiaURI = "https://github.com/kohlstechnology/eunomia"
-	}
-
-	eunomiaRef, found := os.LookupEnv("EUNOMIA_REF")
-	if !found {
-		eunomiaRef = "master"
-	}
+	defer ctx.Cleanup()
 
 	// Step 1: create initial CR, check that pods are started
 
@@ -69,17 +45,17 @@ func TestIssue24RemovedResourceGetsDeleted(t *testing.T) {
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "gitops-issue24",
-			Namespace: namespace,
+			Namespace: ctx.namespace,
 		},
 		Spec: gitopsv1alpha1.GitOpsConfigSpec{
 			TemplateSource: gitopsv1alpha1.GitConfig{
-				URI:        eunomiaURI,
-				Ref:        eunomiaRef,
+				URI:        ctx.eunomiaURI,
+				Ref:        ctx.eunomiaRef,
 				ContextDir: "test/e2e/testdata/issue24/template1",
 			},
 			ParameterSource: gitopsv1alpha1.GitConfig{
-				URI:        eunomiaURI,
-				Ref:        eunomiaRef,
+				URI:        ctx.eunomiaURI,
+				Ref:        ctx.eunomiaRef,
 				ContextDir: "test/e2e/testdata/empty-yaml",
 			},
 			Triggers: []gitopsv1alpha1.GitOpsTrigger{
@@ -93,16 +69,16 @@ func TestIssue24RemovedResourceGetsDeleted(t *testing.T) {
 	}
 	gitops.Annotations = map[string]string{"gitopsconfig.eunomia.kohls.io/initialized": "true"}
 
-	err = framework.Global.Client.Create(context.TODO(), gitops, &framework.CleanupOptions{TestContext: ctx, Timeout: timeout, RetryInterval: retryInterval})
+	err = framework.Global.Client.Create(ctx, gitops, &framework.CleanupOptions{TestContext: ctx.TestCtx, Timeout: timeout, RetryInterval: retryInterval})
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	err = WaitForPodWithImage(t, framework.Global, namespace, "hello-world-issue24", "hello-app:1.0", retryInterval, timeout)
+	err = WaitForPodWithImage(t, framework.Global, ctx.namespace, "hello-world-issue24", "hello-app:1.0", retryInterval, timeout)
 	if err != nil {
 		t.Error(err)
 	}
-	err = WaitForPodWithImage(t, framework.Global, namespace, "now-only", "hello-app:2.0", retryInterval, timeout)
+	err = WaitForPodWithImage(t, framework.Global, ctx.namespace, "now-only", "hello-app:2.0", retryInterval, timeout)
 	if err != nil {
 		t.Error(err)
 	}
@@ -110,12 +86,12 @@ func TestIssue24RemovedResourceGetsDeleted(t *testing.T) {
 	// Step 2: change the CR to one with missing 'now-only' resource, then check that the pod gets deleted
 
 	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		err := framework.Global.Client.Get(context.TODO(), util.GetNN(gitops), gitops)
+		err := framework.Global.Client.Get(ctx, util.GetNN(gitops), gitops)
 		if err != nil {
 			t.Fatal(err)
 		}
 		gitops.Spec.TemplateSource.ContextDir = "test/e2e/testdata/issue24/template2"
-		err = framework.Global.Client.Update(context.Background(), gitops)
+		err = framework.Global.Client.Update(ctx, gitops)
 		return err
 	})
 	if err != nil {
@@ -123,12 +99,12 @@ func TestIssue24RemovedResourceGetsDeleted(t *testing.T) {
 	}
 
 	// Verify that the main "hello-world-issue24" app gets upgraded
-	err = WaitForPodWithImage(t, framework.Global, namespace, "hello-world-issue24", "hello-app:2.0", retryInterval, timeout)
+	err = WaitForPodWithImage(t, framework.Global, ctx.namespace, "hello-world-issue24", "hello-app:2.0", retryInterval, timeout)
 	if err != nil {
 		t.Error(err)
 	}
 	// Verify that the pod corresponding to the missing resource gets deleted
-	err = WaitForPodAbsence(t, framework.Global, namespace, "now-only", "hello-app:2.0", retryInterval, timeout)
+	err = WaitForPodAbsence(t, framework.Global, ctx.namespace, "now-only", "hello-app:2.0", retryInterval, timeout)
 	if err != nil {
 		t.Error(err)
 	}

--- a/test/e2e/issue276_test.go
+++ b/test/e2e/issue276_test.go
@@ -19,9 +19,7 @@ limitations under the License.
 package e2e
 
 import (
-	"context"
 	"fmt"
-	"os"
 	"strings"
 	"testing"
 	"time"
@@ -31,7 +29,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 
-	"github.com/KohlsTechnology/eunomia/pkg/apis"
 	gitopsv1alpha1 "github.com/KohlsTechnology/eunomia/pkg/apis/eunomia/v1alpha1"
 )
 
@@ -50,31 +47,11 @@ func TestIssue276NoTemplatesDir(t *testing.T) {
 		t.Skip("This test currently takes minutes to run, because of exponential backoff in kubernetes")
 	}
 
-	ctx := framework.NewTestCtx(t)
-	defer ctx.Cleanup()
-
-	namespace, err := ctx.GetNamespace()
-	if err != nil {
-		t.Fatalf("could not get namespace: %v", err)
-	}
-	if err = SetupRbacInNamespace(namespace); err != nil {
-		t.Error(err)
-	}
-
-	defer DumpJobsLogsOnError(t, framework.Global, namespace)
-	err = framework.AddToFrameworkScheme(apis.AddToScheme, &gitopsv1alpha1.GitOpsConfigList{})
+	ctx, err := NewContext(t)
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	eunomiaURI, found := os.LookupEnv("EUNOMIA_URI")
-	if !found {
-		eunomiaURI = "https://github.com/kohlstechnology/eunomia"
-	}
-	eunomiaRef, found := os.LookupEnv("EUNOMIA_REF")
-	if !found {
-		eunomiaRef = "master"
-	}
+	defer ctx.Cleanup()
 
 	// Step 1: create a CR with a nonexistent TemplateSource ContextDir
 
@@ -86,20 +63,20 @@ func TestIssue276NoTemplatesDir(t *testing.T) {
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "gitops-issue276",
-			Namespace: namespace,
+			Namespace: ctx.namespace,
 			Finalizers: []string{
 				"gitopsconfig.eunomia.kohls.io/finalizer",
 			},
 		},
 		Spec: gitopsv1alpha1.GitOpsConfigSpec{
 			TemplateSource: gitopsv1alpha1.GitConfig{
-				URI:        eunomiaURI,
-				Ref:        eunomiaRef,
+				URI:        ctx.eunomiaURI,
+				Ref:        ctx.eunomiaRef,
 				ContextDir: noDir,
 			},
 			ParameterSource: gitopsv1alpha1.GitConfig{
-				URI:        eunomiaURI,
-				Ref:        eunomiaRef,
+				URI:        ctx.eunomiaURI,
+				Ref:        ctx.eunomiaRef,
 				ContextDir: "test/e2e/testdata/empty-yaml",
 			},
 			Triggers: []gitopsv1alpha1.GitOpsTrigger{
@@ -113,7 +90,7 @@ func TestIssue276NoTemplatesDir(t *testing.T) {
 	}
 	gitops.Annotations = map[string]string{"gitopsconfig.eunomia.kohls.io/initialized": "true"}
 
-	err = framework.Global.Client.Create(context.TODO(), gitops, &framework.CleanupOptions{TestContext: ctx, Timeout: timeout, RetryInterval: retryInterval})
+	err = framework.Global.Client.Create(ctx, gitops, &framework.CleanupOptions{TestContext: ctx.TestCtx, Timeout: timeout, RetryInterval: retryInterval})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -122,7 +99,7 @@ func TestIssue276NoTemplatesDir(t *testing.T) {
 
 	const name = "gitopsconfig-gitops-issue276-"
 	err = wait.Poll(retryInterval, timeout, func() (done bool, err error) {
-		pod, err := GetPod(namespace, name, "quay.io/kohlstechnology/eunomia-base:dev", framework.Global.KubeClient)
+		pod, err := GetPod(ctx.namespace, name, "quay.io/kohlstechnology/eunomia-base:dev", framework.Global.KubeClient)
 		switch {
 		case apierrors.IsNotFound(err):
 			t.Logf("Waiting for availability of %s pod", name)
@@ -153,13 +130,13 @@ func TestIssue276NoTemplatesDir(t *testing.T) {
 	// Step 3: Delete GitOpsConfig and make sure that the deletion succeeded
 
 	t.Logf("Deleting CR")
-	err = framework.Global.Client.Delete(context.TODO(), gitops)
+	err = framework.Global.Client.Delete(ctx, gitops)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// Three minutes timeout.
-	err = WaitForPodAbsence(t, framework.Global, namespace, name, "quay.io/kohlstechnology/eunomia-base:dev", retryInterval, 3*time.Minute)
+	err = WaitForPodAbsence(t, framework.Global, ctx.namespace, name, "quay.io/kohlstechnology/eunomia-base:dev", retryInterval, 3*time.Minute)
 	if err != nil {
 		t.Error(err)
 	}
@@ -169,31 +146,11 @@ func TestIssue276NoTemplatesDir(t *testing.T) {
 // passes a TemplateSource directory containing no resource files, but
 // only a single ".gitkeep" file
 func TestIssue276EmptyTemplatesDir(t *testing.T) {
-	ctx := framework.NewTestCtx(t)
-	defer ctx.Cleanup()
-
-	namespace, err := ctx.GetNamespace()
-	if err != nil {
-		t.Fatalf("could not get namespace: %v", err)
-	}
-	if err = SetupRbacInNamespace(namespace); err != nil {
-		t.Error(err)
-	}
-
-	defer DumpJobsLogsOnError(t, framework.Global, namespace)
-	err = framework.AddToFrameworkScheme(apis.AddToScheme, &gitopsv1alpha1.GitOpsConfigList{})
+	ctx, err := NewContext(t)
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	eunomiaURI, found := os.LookupEnv("EUNOMIA_URI")
-	if !found {
-		eunomiaURI = "https://github.com/kohlstechnology/eunomia"
-	}
-	eunomiaRef, found := os.LookupEnv("EUNOMIA_REF")
-	if !found {
-		eunomiaRef = "master"
-	}
+	defer ctx.Cleanup()
 
 	// Step 1: create a CR with a TemplateSource ContextDir containing only a ".gitkeep" file
 
@@ -204,20 +161,20 @@ func TestIssue276EmptyTemplatesDir(t *testing.T) {
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "gitops-issue276",
-			Namespace: namespace,
+			Namespace: ctx.namespace,
 			Finalizers: []string{
 				"gitopsconfig.eunomia.kohls.io/finalizer",
 			},
 		},
 		Spec: gitopsv1alpha1.GitOpsConfigSpec{
 			TemplateSource: gitopsv1alpha1.GitConfig{
-				URI:        eunomiaURI,
-				Ref:        eunomiaRef,
+				URI:        ctx.eunomiaURI,
+				Ref:        ctx.eunomiaRef,
 				ContextDir: "test/e2e/testdata/empty-directory",
 			},
 			ParameterSource: gitopsv1alpha1.GitConfig{
-				URI:        eunomiaURI,
-				Ref:        eunomiaRef,
+				URI:        ctx.eunomiaURI,
+				Ref:        ctx.eunomiaRef,
 				ContextDir: "test/e2e/testdata/empty-yaml",
 			},
 			Triggers: []gitopsv1alpha1.GitOpsTrigger{
@@ -231,7 +188,7 @@ func TestIssue276EmptyTemplatesDir(t *testing.T) {
 	}
 	gitops.Annotations = map[string]string{"gitopsconfig.eunomia.kohls.io/initialized": "true"}
 
-	err = framework.Global.Client.Create(context.TODO(), gitops, &framework.CleanupOptions{TestContext: ctx, Timeout: timeout, RetryInterval: retryInterval})
+	err = framework.Global.Client.Create(ctx, gitops, &framework.CleanupOptions{TestContext: ctx.TestCtx, Timeout: timeout, RetryInterval: retryInterval})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -240,7 +197,7 @@ func TestIssue276EmptyTemplatesDir(t *testing.T) {
 
 	err = wait.Poll(retryInterval, timeout, func() (done bool, err error) {
 		const name = "gitopsconfig-gitops-issue276-"
-		pod, err := GetPod(namespace, name, "quay.io/kohlstechnology/eunomia-base:dev", framework.Global.KubeClient)
+		pod, err := GetPod(ctx.namespace, name, "quay.io/kohlstechnology/eunomia-base:dev", framework.Global.KubeClient)
 		switch {
 		case apierrors.IsNotFound(err):
 			t.Logf("Waiting for availability of %s pod", name)

--- a/test/e2e/modes_test.go
+++ b/test/e2e/modes_test.go
@@ -19,46 +19,22 @@ limitations under the License.
 package e2e
 
 import (
-	"context"
-	"os"
 	"testing"
 
 	framework "github.com/operator-framework/operator-sdk/pkg/test"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/retry"
 
-	"github.com/KohlsTechnology/eunomia/pkg/apis"
 	gitopsv1alpha1 "github.com/KohlsTechnology/eunomia/pkg/apis/eunomia/v1alpha1"
 	"github.com/KohlsTechnology/eunomia/pkg/util"
 )
 
 func TestModesCreateReplaceDelete(t *testing.T) {
-	ctx := framework.NewTestCtx(t)
-	defer ctx.Cleanup()
-
-	namespace, err := ctx.GetNamespace()
-	if err != nil {
-		t.Fatalf("could not get namespace: %v", err)
-	}
-	if err = SetupRbacInNamespace(namespace); err != nil {
-		t.Error(err)
-	}
-
-	defer DumpJobsLogsOnError(t, framework.Global, namespace)
-	err = framework.AddToFrameworkScheme(apis.AddToScheme, &gitopsv1alpha1.GitOpsConfigList{})
+	ctx, err := NewContext(t)
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	eunomiaURI, found := os.LookupEnv("EUNOMIA_URI")
-	if !found {
-		eunomiaURI = "https://github.com/kohlstechnology/eunomia"
-	}
-
-	eunomiaRef, found := os.LookupEnv("EUNOMIA_REF")
-	if !found {
-		eunomiaRef = "master"
-	}
+	defer ctx.Cleanup()
 
 	// Step 1: create initial CR with "Create" mode, check that pods are started
 
@@ -69,17 +45,17 @@ func TestModesCreateReplaceDelete(t *testing.T) {
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "gitops-modes",
-			Namespace: namespace,
+			Namespace: ctx.namespace,
 		},
 		Spec: gitopsv1alpha1.GitOpsConfigSpec{
 			TemplateSource: gitopsv1alpha1.GitConfig{
-				URI:        eunomiaURI,
-				Ref:        eunomiaRef,
+				URI:        ctx.eunomiaURI,
+				Ref:        ctx.eunomiaRef,
 				ContextDir: "test/e2e/testdata/modes/template1",
 			},
 			ParameterSource: gitopsv1alpha1.GitConfig{
-				URI:        eunomiaURI,
-				Ref:        eunomiaRef,
+				URI:        ctx.eunomiaURI,
+				Ref:        ctx.eunomiaRef,
 				ContextDir: "test/e2e/testdata/empty-yaml",
 			},
 			Triggers: []gitopsv1alpha1.GitOpsTrigger{
@@ -93,12 +69,12 @@ func TestModesCreateReplaceDelete(t *testing.T) {
 	}
 	gitops.Annotations = map[string]string{"gitopsconfig.eunomia.kohls.io/initialized": "true"}
 
-	err = framework.Global.Client.Create(context.TODO(), gitops, &framework.CleanupOptions{TestContext: ctx, Timeout: timeout, RetryInterval: retryInterval})
+	err = framework.Global.Client.Create(ctx, gitops, &framework.CleanupOptions{TestContext: ctx.TestCtx, Timeout: timeout, RetryInterval: retryInterval})
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	err = WaitForPodWithImage(t, framework.Global, namespace, "hello-world-modes", "hello-app:1.0", retryInterval, timeout)
+	err = WaitForPodWithImage(t, framework.Global, ctx.namespace, "hello-world-modes", "hello-app:1.0", retryInterval, timeout)
 	if err != nil {
 		t.Error(err)
 	}
@@ -106,20 +82,20 @@ func TestModesCreateReplaceDelete(t *testing.T) {
 	// Step 2: change the CR to a different version of image, using "Replace" mode, then verify pod change
 
 	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		err := framework.Global.Client.Get(context.TODO(), util.GetNN(gitops), gitops)
+		err := framework.Global.Client.Get(ctx, util.GetNN(gitops), gitops)
 		if err != nil {
 			t.Fatal(err)
 		}
 		gitops.Spec.TemplateSource.ContextDir = "test/e2e/testdata/modes/template2"
 		gitops.Spec.ResourceHandlingMode = "Replace"
-		err = framework.Global.Client.Update(context.Background(), gitops)
+		err = framework.Global.Client.Update(ctx, gitops)
 		return err
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
 	// Verify that the main "hello-world-modes" app gets upgraded
-	err = WaitForPodWithImage(t, framework.Global, namespace, "hello-world-modes", "hello-app:2.0", retryInterval, timeout)
+	err = WaitForPodWithImage(t, framework.Global, ctx.namespace, "hello-world-modes", "hello-app:2.0", retryInterval, timeout)
 	if err != nil {
 		t.Error(err)
 	}
@@ -127,19 +103,19 @@ func TestModesCreateReplaceDelete(t *testing.T) {
 	// Step 2: change the CR to "Delete" mode, then verify that the Pod is deleted
 
 	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		err := framework.Global.Client.Get(context.TODO(), util.GetNN(gitops), gitops)
+		err := framework.Global.Client.Get(ctx, util.GetNN(gitops), gitops)
 		if err != nil {
 			t.Fatal(err)
 		}
 		gitops.Spec.ResourceHandlingMode = "Delete"
-		err = framework.Global.Client.Update(context.Background(), gitops)
+		err = framework.Global.Client.Update(ctx, gitops)
 		return err
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
 	// Verify that the pod corresponding to the missing resource gets deleted
-	err = WaitForPodAbsence(t, framework.Global, namespace, "hello-world-modes", "hello-app:2.0", retryInterval, timeout)
+	err = WaitForPodAbsence(t, framework.Global, ctx.namespace, "hello-world-modes", "hello-app:2.0", retryInterval, timeout)
 	if err != nil {
 		t.Error(err)
 	}

--- a/test/e2e/ocp_template_test.go
+++ b/test/e2e/ocp_template_test.go
@@ -19,14 +19,11 @@ limitations under the License.
 package e2e
 
 import (
-	goctx "context"
-	"os"
 	"testing"
 
 	framework "github.com/operator-framework/operator-sdk/pkg/test"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/KohlsTechnology/eunomia/pkg/apis"
 	gitopsv1alpha1 "github.com/KohlsTechnology/eunomia/pkg/apis/eunomia/v1alpha1"
 )
 
@@ -35,31 +32,11 @@ DISABLED
 TODO create a make file and have a specific minihift-e2e-test, the below  test does not work with minikube.
 */
 func disabledOCPTemplate(t *testing.T) {
-	ctx := framework.NewTestCtx(t)
-	defer ctx.Cleanup()
-
-	namespace, err := ctx.GetNamespace()
-	if err != nil {
-		t.Fatalf("could not get namespace: %v", err)
-	}
-	if err = SetupRbacInNamespace(namespace); err != nil {
-		t.Error(err)
-	}
-
-	err = framework.AddToFrameworkScheme(apis.AddToScheme, &gitopsv1alpha1.GitOpsConfigList{})
+	ctx, err := NewContext(t)
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	eunomiaURI, found := os.LookupEnv("EUNOMIA_URI")
-	if !found {
-		eunomiaURI = "https://github.com/kohlstechnology/eunomia"
-	}
-
-	eunomiaRef, found := os.LookupEnv("EUNOMIA_REF")
-	if !found {
-		eunomiaRef = "master"
-	}
+	defer ctx.Cleanup()
 
 	gitops := &gitopsv1alpha1.GitOpsConfig{
 		TypeMeta: metav1.TypeMeta{
@@ -68,17 +45,17 @@ func disabledOCPTemplate(t *testing.T) {
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "gitops-ocp",
-			Namespace: namespace,
+			Namespace: ctx.namespace,
 		},
 		Spec: gitopsv1alpha1.GitOpsConfigSpec{
 			TemplateSource: gitopsv1alpha1.GitConfig{
-				URI:        eunomiaURI,
-				Ref:        eunomiaRef,
+				URI:        ctx.eunomiaURI,
+				Ref:        ctx.eunomiaRef,
 				ContextDir: "test/e2e/testdata/simple/templates",
 			},
 			ParameterSource: gitopsv1alpha1.GitConfig{
-				URI:        eunomiaURI,
-				Ref:        eunomiaRef,
+				URI:        ctx.eunomiaURI,
+				Ref:        ctx.eunomiaRef,
 				ContextDir: "test/e2e/testdata/simple/parameters",
 			},
 			Triggers: []gitopsv1alpha1.GitOpsTrigger{
@@ -92,12 +69,12 @@ func disabledOCPTemplate(t *testing.T) {
 	}
 	gitops.Annotations = map[string]string{"gitopsconfig.eunomia.kohls.io/initialized": "true"}
 
-	err = framework.Global.Client.Create(goctx.TODO(), gitops, &framework.CleanupOptions{TestContext: ctx, Timeout: timeout, RetryInterval: retryInterval})
+	err = framework.Global.Client.Create(ctx, gitops, &framework.CleanupOptions{TestContext: ctx.TestCtx, Timeout: timeout, RetryInterval: retryInterval})
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	err = WaitForPod(t, framework.Global, namespace, "helloworld", retryInterval, timeout)
+	err = WaitForPod(t, framework.Global, ctx.namespace, "helloworld", retryInterval, timeout)
 	if err != nil {
 		t.Error(err)
 	}


### PR DESCRIPTION
<!--
    Please read https://github.com/KohlsTechnology/eunomia/blob/master/.github/CONTRIBUTING.md before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->
Refactor the code commonly repeated at the beginning of most e2e tests into a separate function, and modify the tests to use the helper function.

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #214

Also, change the `template-processors/base/bin/gitClone.sh` script to only do a shallow git clone (skip downloading and cloning full git history of the repositories, keep only the state at last commit).

**Type of change**

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)

**Checklist**

- [x] Unit tests and e2e tests updated
- [ ] ~~Documentation updated~~ — *N/A*
