### PR TITLE
add support for submodules

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,29 @@ If a secret is provided, then it is assumed that the connection to Git requires 
 
 If the `uri` is not specified in the `parameterSource` section, then it will default to the `uri` specified under `templateSource`.
 
+### Git Submodules
+
+Some helm charts might require the configuration to be part of the chart itself (you can't read files from outside the chart). Loading files into a configmap is one example of this. 
+
+Separating the charts (templateSource) from the actual configuration (parameterSource) is a best practice. This allows you to separate your code (templates) from your configuration, which helps tremendously with change management.
+
+The best way to go about this is to use the config repo as a submodule and point to the master branch. During development you can of course point against another branch, just make sure you correct it in `.gitmodules` before the PR gets merged.
+
+#### Add submodule to track master branch
+
+```
+git submodule add -b master <repo-url>
+```
+
+#### Checking out a repo with submodules
+
+```
+git clone <repo-url>
+cd <repo>
+git submodule init
+git submodule update --recursive --remote
+```
+
 ### parameterSource processing
 Eunomia uses the [yq command](http://mikefarah.github.io/yq/) to merge all yaml files in the specified folder. You have to be careful, if you have the same variable name in multiple files. Dictionaries will merge, lists will get overwritten.
 

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Some helm charts might require the configuration to be part of the chart itself 
 
 Separating the charts (templateSource) from the actual configuration (parameterSource) is a best practice. This allows you to separate your code (templates) from your configuration, which helps tremendously with change management.
 
-The best way to go about this is to use the config repo as a submodule and point to the master branch. During development you can of course point against another branch, just make sure you correct it in `.gitmodules` before the PR gets merged.
+One way to go about this is to use the config repo as a submodule and point to the master branch. During development you can of course point against another branch, just make sure you correct it in `.gitmodules` before the PR gets merged.
 
 #### Add submodule to track master branch
 

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -243,6 +243,31 @@ hello_world_hierarchy_cr1
 # Delete namespaces after Testing hello-world-hierarchy example
 kubectl delete namespace eunomia-hello-world-demo eunomia-hello-world-demo-hierarchy
 
+#Test git_submodules
+git_submodules() {
+    timeout=60
+    kubectl apply -f test/e2e/testdata/submodule/hello-world-submodule-cr.yaml -n eunomia-hello-world-yaml-demo
+    while ((--timeout)) && [[ "$(kubectl get po -n eunomia-hello-world-yaml-demo -l name=hello-world -o=jsonpath="{range .items[*]}{.status.phase}{'\n'}{end}")" != "Running" ]]; do
+        echo "waiting for hello-world-yaml-cr1 deployment: remaining $timeout sec..."
+        sleep 1
+    done
+    if [[ $timeout == 0 ]]; then
+        echo "git_submodules Test FAILED"
+        exit 1
+    fi
+    echo "git_submodules Test Passed"
+}
+
+# Create new namespace
+kubectl create namespace eunomia-hello-world-yaml-demo
+# Create new service account for the runners
+kubectl apply -f examples/hello-world-yaml/eunomia-runner-sa.yaml -n eunomia-hello-world-yaml-demo
+
+git_submodules
+
+# Delete namespaces after Testing hello-world-yaml example
+kubectl delete namespace eunomia-hello-world-yaml-demo
+
 # Eunomia teardown
 helm template deploy/helm/eunomia-operator/ \
     --set eunomia.operator.image.tag=dev \

--- a/template-processors/base/bin/gitClone.sh
+++ b/template-processors/base/bin/gitClone.sh
@@ -39,6 +39,10 @@ function pullFromTemplatesRepo() {
         export https_proxy
         export no_proxy
         git clone --depth 1 --shallow-submodules -b "$TEMPLATE_GIT_REF" "$TEMPLATE_GIT_URI" "$TEMPLATE_GIT_DIR"
+        pushd "$TEMPLATE_GIT_DIR"
+        git submodule init
+        git submodule update --recursive --remote
+        popd
     )
 }
 
@@ -65,6 +69,10 @@ function pullFromParametersRepo() {
         export https_proxy
         export no_proxy
         git clone --depth 1 --shallow-submodules -b "$PARAMETER_GIT_REF" "$PARAMETER_GIT_URI" "$PARAMETER_GIT_DIR"
+        pushd "$PARAMETER_GIT_DIR"
+        git submodule init
+        git submodule update --recursive --remote
+        popd
     )
 }
 

--- a/test/e2e/testdata/submodule/hello-world-submodule-cr.yaml
+++ b/test/e2e/testdata/submodule/hello-world-submodule-cr.yaml
@@ -1,0 +1,18 @@
+apiVersion: eunomia.kohls.io/v1alpha1
+kind: GitOpsConfig
+metadata:
+  name: hello-world-yaml
+spec:
+  templateSource:
+    uri: https://github.com/KohlsTechnology/eunomia-test-submodules
+    ref: master
+    contextDir: eunomia/examples/hello-world-yaml/template1
+  parameterSource:
+    ref: master
+    contextDir: eunomia/examples/hello-world-yaml/parameters
+  triggers:
+  - type: Change
+  serviceAccountRef: eunomia-runner-yaml
+  templateProcessorImage: quay.io/kohlstechnology/eunomia-base:latest
+  resourceHandlingMode: Apply
+  resourceDeletionMode: Delete


### PR DESCRIPTION
**Description**

Add the ability to have repositories with submodules, which point at a specific branch instead of a commit. This allows the separation of helm charts that need to read files (e.g. configmaps) from their configuration.

**Type of change**

* Bug fix (non-breaking change which fixes an issue)

**Checklist**

- [x] Unit tests and e2e tests updated
- [x] Documentation updated
