### PR TITLE
Improve e2e testing and allow to be run locally

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ before_script:
 - curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/${KUBE_VERSION}/bin/linux/amd64/kubectl
 - sudo chmod +x kubectl && sudo mv kubectl /usr/local/bin/
 - |
-  if [[ "$MINIKUBE_VERSION" ]]; then
+  if [[ "${EUNOMIA_TEST_ENV}" == "minikube" ]]; then
     curl -Lo minikube https://storage.googleapis.com/minikube/releases/${MINIKUBE_VERSION}/minikube-linux-amd64
     sudo chmod +x minikube
     sudo mv minikube /usr/local/bin/
@@ -53,10 +53,10 @@ before_script:
 - curl -Lo shfmt https://github.com/mvdan/sh/releases/download/${SHFMT_VERSION}/shfmt_${SHFMT_VERSION}_linux_amd64
 - sudo chmod +x shfmt && sudo mv shfmt /usr/local/bin/
 - |
-  if [[ "$MINIKUBE_VERSION" ]]; then
+  if [[ "${EUNOMIA_TEST_ENV}" == "minikube" ]]; then
     sudo minikube start --vm-driver=none --kubernetes-version=${KUBE_VERSION}
     minikube update-context
-  elif [[ "$MINISHIFT_VERSION" ]]; then
+  elif [[ "${EUNOMIA_TEST_ENV}" == "minishift" ]]; then
     bash -x ci/prepare-host minishift
     bash -x ci/start-cluster minishift ${MINISHIFT_VERSION}
   fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,9 @@ env:
   # NOTE: We can add 200 items to the build matrix, but only 3 run in parallel. So having more than three
   # items in the build matrix will cause the tests to wait in a queue. We will need to select the k8s versions
   # that we want to test carefully, or we risk having the tests run for a very long time.
-  - OPERATOR_SDK_VERSION=v0.8.1 KUBE_VERSION=v1.15.10 MINIKUBE_VERSION=v1.6.2 SHFMT_VERSION=v3.0.1 TEST_ENV=minikube
-  - OPERATOR_SDK_VERSION=v0.8.1 KUBE_VERSION=v1.16.7 MINIKUBE_VERSION=v1.6.2 SHFMT_VERSION=v3.0.1 TEST_ENV=minikube
-  - OPERATOR_SDK_VERSION=v0.8.1 KUBE_VERSION=v1.11.0 MINISHIFT_VERSION=3.11.0 SHFMT_VERSION=v3.0.1 TEST_ENV=minishift
+  - OPERATOR_SDK_VERSION=v0.8.1 KUBE_VERSION=v1.15.10 MINIKUBE_VERSION=v1.6.2 SHFMT_VERSION=v3.0.1 EUNOMIA_TEST_ENV=minikube
+  - OPERATOR_SDK_VERSION=v0.8.1 KUBE_VERSION=v1.16.7 MINIKUBE_VERSION=v1.6.2 SHFMT_VERSION=v3.0.1 EUNOMIA_TEST_ENV=minikube
+  - OPERATOR_SDK_VERSION=v0.8.1 KUBE_VERSION=v1.11.0 MINISHIFT_VERSION=3.11.0 SHFMT_VERSION=v3.0.1 EUNOMIA_TEST_ENV=minishift
 
 before_install:
   - travis_retry go mod vendor

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,9 @@ env:
   # NOTE: We can add 200 items to the build matrix, but only 3 run in parallel. So having more than three
   # items in the build matrix will cause the tests to wait in a queue. We will need to select the k8s versions
   # that we want to test carefully, or we risk having the tests run for a very long time.
-  - OPERATOR_SDK_VERSION=v0.8.1 KUBE_VERSION=v1.15.10 MINIKUBE_VERSION=v1.6.2 SHFMT_VERSION=v3.0.1
-  - OPERATOR_SDK_VERSION=v0.8.1 KUBE_VERSION=v1.16.7 MINIKUBE_VERSION=v1.6.2 SHFMT_VERSION=v3.0.1
-  - OPERATOR_SDK_VERSION=v0.8.1 KUBE_VERSION=v1.11.0 OPENSHIFT_VERSION=3.11.0 SHFMT_VERSION=v3.0.1
+  - OPERATOR_SDK_VERSION=v0.8.1 KUBE_VERSION=v1.15.10 MINIKUBE_VERSION=v1.6.2 SHFMT_VERSION=v3.0.1 TEST_ENV=minikube
+  - OPERATOR_SDK_VERSION=v0.8.1 KUBE_VERSION=v1.16.7 MINIKUBE_VERSION=v1.6.2 SHFMT_VERSION=v3.0.1 TEST_ENV=minikube
+  - OPERATOR_SDK_VERSION=v0.8.1 KUBE_VERSION=v1.11.0 MINISHIFT_VERSION=3.11.0 SHFMT_VERSION=v3.0.1 TEST_ENV=minishift
 
 before_install:
   - travis_retry go mod vendor
@@ -56,9 +56,9 @@ before_script:
   if [[ "$MINIKUBE_VERSION" ]]; then
     sudo minikube start --vm-driver=none --kubernetes-version=${KUBE_VERSION}
     minikube update-context
-  elif [[ "$OPENSHIFT_VERSION" ]]; then
+  elif [[ "$MINISHIFT_VERSION" ]]; then
     bash -x ci/prepare-host minishift
-    bash -x ci/start-cluster minishift ${OPENSHIFT_VERSION}
+    bash -x ci/start-cluster minishift ${MINISHIFT_VERSION}
   fi
 - JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'; until kubectl get nodes -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1; done
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -210,8 +210,8 @@ make test-unit
 ```shell
 # Optional: Set the environment variable $EUNOMIA_URI to point to a specific git url for testing
 # Optional: Set the environment variable $EUNOMIA_REF to point to a specific git reference for testing
-# Optional: Set the environment variable $TEST_ENV to minishift (default is minikube)
-# Optional: Set the environment variable $TEST_PAUSE to yes (default is no)
+# Optional: Set the environment variable $EUNOMIA_TEST_ENV to minishift (default is minikube)
+# Optional: Set the environment variable $EUNOMIA_TEST_PAUSE to yes (default is no)
 make test-e2e
 ```
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -210,6 +210,7 @@ make test-unit
 ```shell
 # Optional: Set the environment variable $EUNOMIA_URI to point to a specific git url for testing
 # Optional: Set the environment variable $EUNOMIA_REF to point to a specific git reference for testing
+# Optional: Set the environment variable $TEST_ENV to minishift (default is minikube)
 make test-e2e
 ```
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -211,6 +211,7 @@ make test-unit
 # Optional: Set the environment variable $EUNOMIA_URI to point to a specific git url for testing
 # Optional: Set the environment variable $EUNOMIA_REF to point to a specific git reference for testing
 # Optional: Set the environment variable $TEST_ENV to minishift (default is minikube)
+# Optional: Set the environment variable $TEST_PAUSE to yes (default is no)
 make test-e2e
 ```
 

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ export GITHUB_PAGES_BRANCH ?= gh-pages
 export GITHUB_PAGES_REPO ?= KohlsTechnology/eunomia
 export HELM_CHARTS_SOURCE ?= deploy/helm/eunomia-operator
 export HELM_CHART_DEST ?= $(GITHUB_PAGES_DIR)
+export TEST_ENV ?= minikube
 
 .PHONY: all
 all: build

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -46,6 +46,7 @@ function wait_for_gitopsconfig_completion() {
     timeout=60
     ALL_GOOD=0
     JOBS=""
+    # Count down `timeout` to 0, then fail to avoid locking situations
     while ((--timeout)) && [[ "${ALL_GOOD}" == "0" ]]; do
         JOBS=$(kubectl get jobs -n "${NAMESPACE}" -o name | sed 's/job.batch\///g')
         if [ -z "${JOBS}" ]; then
@@ -89,7 +90,7 @@ function validate_job_count() {
     fi
 }
 
-# Returns the active replicas for hello-world
+# Returns the active replicas count
 # Usage get_replica_count <namespace> <image> <labelname>
 # Example: get_replica_count "eunomia-hello-world-yaml-demo" "gcr.io/google-samples/hello-app:2.0" "hello-world"
 function get_replica_count() {

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -16,6 +16,8 @@
 
 set -euo pipefail
 
+export OPERATOR_SDK_VERSION="v0.8.1"
+
 usage() {
     cat <<EOT
 e2e-test.sh [-e|--env=(minikube|minishift)] [-p|--pause]
@@ -104,6 +106,11 @@ EUNOMIA_PATH=$(
     cd "${0%/*}/.."
     pwd
 )
+
+if ! operator-sdk version | grep "${OPERATOR_SDK_VERSION}"; then
+    echo "Error: Operator-SDK ${OPERATOR_SDK_VERSION} not found"
+    exit 1
+fi
 
 # Process the command line parameters
 PARAMS=""

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -303,22 +303,22 @@ hello_world_yaml_cr_3() {
 }
 
 hello_world_yaml_cr_1
-echo "Waiting 15 to verify no other gitopsconfig gets started"
+echo "Waiting 15s to verify no other gitopsconfig gets started"
 sleep 15
 wait_for_gitopsconfig_completion eunomia-hello-world-yaml-demo
-# don't enable validate_job_count until somebody fixes the bug for multiple jobs being started
+# don't enable validate_job_count until somebody fixes the bug for multiple jobs being started (issue #343)
 #validate_job_count eunomia-hello-world-yaml-demo 1
 pause
 
 hello_world_yaml_cr_2
 wait_for_gitopsconfig_completion eunomia-hello-world-yaml-demo
-# don't enable validate_job_count until somebody fixes the bug for multiple jobs being started
+# don't enable validate_job_count until somebody fixes the bug for multiple jobs being started (issue #343)
 #validate_job_count eunomia-hello-world-yaml-demo 2
 pause
 
 hello_world_yaml_cr_3
 wait_for_gitopsconfig_completion eunomia-hello-world-yaml-demo
-# don't enable validate_job_count until somebody fixes the bug for multiple jobs being started
+# don't enable validate_job_count until somebody fixes the bug for multiple jobs being started (issue #343)
 #validate_job_count eunomia-hello-world-yaml-demo 3
 pause
 
@@ -378,22 +378,22 @@ hello_world_helm_cr3() {
 }
 
 hello_world_helm_cr1
-echo "Waiting 15 to verify no other gitopsconfig gets started"
+echo "Waiting 15s to verify no other gitopsconfig gets started"
 sleep 15
 wait_for_gitopsconfig_completion eunomia-hello-world-demo
-# don't enable validate_job_count until somebody fixes the bug for multiple jobs being started
+# don't enable validate_job_count until somebody fixes the bug for multiple jobs being started (issue #343)
 #validate_job_count eunomia-hello-world-demo 1
 pause
 
 hello_world_helm_cr2
 wait_for_gitopsconfig_completion eunomia-hello-world-demo
-# don't enable validate_job_count until somebody fixes the bug for multiple jobs being started
+# don't enable validate_job_count until somebody fixes the bug for multiple jobs being started (issue #343)
 #validate_job_count eunomia-hello-world-demo 1
 pause
 
 hello_world_helm_cr3
 wait_for_gitopsconfig_completion eunomia-hello-world-demo
-# don't enable validate_job_count until somebody fixes the bug for multiple jobs being started
+# don't enable validate_job_count until somebody fixes the bug for multiple jobs being started (issue #343)
 #validate_job_count eunomia-hello-world-demo 1
 pause
 
@@ -422,10 +422,10 @@ hello_world_hierarchy_cr1() {
 }
 
 hello_world_hierarchy_cr1
-echo "Waiting 15 to verify no other gitopsconfig gets started"
+echo "Waiting 15s to verify no other gitopsconfig gets started"
 sleep 15
 wait_for_gitopsconfig_completion eunomia-hello-world-demo
-# don't enable validate_job_count until somebody fixes the bug for multiple jobs being started
+# don't enable validate_job_count until somebody fixes the bug for multiple jobs being started (issue #343)
 #validate_job_count eunomia-hello-world-demo 1
 pause
 

--- a/scripts/install-operator-sdk.sh
+++ b/scripts/install-operator-sdk.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+# Copyright 2019 Kohl's Department Stores, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euxo pipefail
+
+RELEASE_VERSION=${1}
+TARGET_PATH=${2}
+
+OS="$(uname)"
+
+if [ "${OS}" = "Darwin" ]; then
+    curl -OJL "https://github.com/operator-framework/operator-sdk/releases/download/${RELEASE_VERSION}/operator-sdk-${RELEASE_VERSION}-x86_64-apple-darwin"
+    chmod +x "operator-sdk-${RELEASE_VERSION}-x86_64-apple-darwin" && cp "operator-sdk-${RELEASE_VERSION}-x86_64-apple-darwin" "${TARGET_PATH}/operator-sdk" && rm "operator-sdk-${RELEASE_VERSION}-x86_64-apple-darwin"
+elif [ "${OS}" == "Linux" ]; then
+    curl -OJL "https://github.com/operator-framework/operator-sdk/releases/download/${RELEASE_VERSION}/operator-sdk-${RELEASE_VERSION}-x86_64-linux-gnu"
+    chmod +x "operator-sdk-${RELEASE_VERSION}-x86_64-linux-gnu" && cp "operator-sdk-${RELEASE_VERSION}-x86_64-linux-gnu" "${TARGET_PATH}/operator-sdk" && rm "operator-sdk-${RELEASE_VERSION}-x86_64-linux-gnu"
+else
+    echo "Sorry, your OS is currently not supported. We'll happily accept a pull request to add it... :)"
+fi

--- a/scripts/install-operator-sdk.sh
+++ b/scripts/install-operator-sdk.sh
@@ -21,7 +21,7 @@ TARGET_PATH=${2}
 
 OS="$(uname)"
 
-if [ "${OS}" = "Darwin" ]; then
+if [ "${OS}" == "Darwin" ]; then
     curl -OJL "https://github.com/operator-framework/operator-sdk/releases/download/${RELEASE_VERSION}/operator-sdk-${RELEASE_VERSION}-x86_64-apple-darwin"
     chmod +x "operator-sdk-${RELEASE_VERSION}-x86_64-apple-darwin" && cp "operator-sdk-${RELEASE_VERSION}-x86_64-apple-darwin" "${TARGET_PATH}/operator-sdk" && rm "operator-sdk-${RELEASE_VERSION}-x86_64-apple-darwin"
 elif [ "${OS}" == "Linux" ]; then


### PR DESCRIPTION
**Description**

Currently the e2e tests have hidden dependencies to some environment variables, which control the behavior of the script. It also fixes a number of reliability and consistency issues with the test themselves.

New command line parameters have been introduced to `e2e-test.sh` to help running it and using it for development:
```
e2e-test.sh [-e|--env=(minikube|minishift)] [-p|--pause]

Execute the end-to-end tests on a local minikube or minishift.

-e|--env=(minikube|minishift) sets the environment the tests will be run under
-p|--pause Pauses after each test step to help with debugging

You can also specify the settings via environment variables (command line parameters take precedence).
EUNOMIA_TEST_ENV=(minikube|minishift)
EUNOMIA_TEST_PAUSE=yes
```

This PR also adds a script to install the correct operator-sdk version, to make upgrades easier.

**Type of change**

* Bug fix (non-breaking change which fixes an issue)

**Checklist**

- [X] Unit tests and e2e tests updated
- [X] Documentation updated
