### PR TITLE
Add missing EUNOMIA_TEST_ENV=minikube to Travis deploy stages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,11 +70,11 @@ jobs:
   include:
     - stage: deploy
       env:
-        - OPERATOR_SDK_VERSION=v0.8.1 KUBE_VERSION=v1.15.10 MINIKUBE_VERSION=v1.6.2 SHFMT_VERSION=v3.0.1
+        - OPERATOR_SDK_VERSION=v0.8.1 KUBE_VERSION=v1.15.10 MINIKUBE_VERSION=v1.6.2 SHFMT_VERSION=v3.0.1 EUNOMIA_TEST_ENV=minikube
       script: make travis-deploy-images
     - stage: deploy-release
       env:
-        - OPERATOR_SDK_VERSION=v0.8.1 KUBE_VERSION=v1.15.10 MINIKUBE_VERSION=v1.6.2 SHFMT_VERSION=v3.0.1
+        - OPERATOR_SDK_VERSION=v0.8.1 KUBE_VERSION=v1.15.10 MINIKUBE_VERSION=v1.6.2 SHFMT_VERSION=v3.0.1 EUNOMIA_TEST_ENV=minikube
       script: make travis-release
 
 stages:


### PR DESCRIPTION
**Description**

Resolve an issue introduced with PR #341 , not correctly setting `EUNOMIA_TEST_ENV=minikube` for the Travis deploy stages.

**Type of change**
* Bug fix (non-breaking change which fixes an issue)

**Checklist**

- [N/A] Unit tests and e2e tests updated
- [N/A] Documentation updated
