### PR TITLE
pkg/handler: improve clarity in webhook handler

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -52,7 +52,7 @@ var (
 	metricsHost       = "0.0.0.0"
 	metricsPort int32 = 8383
 )
-var log = logf.Log.WithName("cmd")
+var log = logf.Log.WithName("cmd").WithValues("filename", "main.go")
 
 func printVersion() {
 	log.Info(fmt.Sprintf("Eunomia version: %s (build date: %s, branch: %s, git SHA1: %s)", version.Version, version.BuildDate, version.Branch, version.GitSHA1))

--- a/pkg/controller/gitopsconfig/controller.go
+++ b/pkg/controller/gitopsconfig/controller.go
@@ -44,7 +44,7 @@ import (
 	"github.com/KohlsTechnology/eunomia/pkg/util"
 )
 
-var log = logf.Log.WithName(controllerName)
+var log = logf.Log.WithName(controllerName).WithValues("filename", "controller.go")
 
 const (
 	tagInitialized string = "gitopsconfig.eunomia.kohls.io/initialized"

--- a/pkg/handler/handler.go
+++ b/pkg/handler/handler.go
@@ -67,12 +67,8 @@ func WebhookHandler(w http.ResponseWriter, r *http.Request, reconciler gitopscon
 			targetList := gitopsv1alpha1.GitOpsConfigList{
 				TypeMeta: list.TypeMeta,
 				ListMeta: list.ListMeta,
-				Items:    make([]gitopsv1alpha1.GitOpsConfig, len(list.Items)),
+				Items:    make([]gitopsv1alpha1.GitOpsConfig, 0, len(list.Items)),
 			}
-
-			// The targetList.Items is initialized with an empty GitOpsConfig at index 0
-			// We are dropping this item to ensure we do not try to start a reconsiliation job for an "empty" GitOpsConfig resource
-			targetList.Items = targetList.Items[1:]
 
 			for _, instance := range list.Items {
 				if !gitopsconfig.ContainsTrigger(&instance, "Webhook") {

--- a/pkg/handler/handler.go
+++ b/pkg/handler/handler.go
@@ -28,7 +28,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
-var log = logf.Log.WithName("handler")
+var log = logf.Log.WithName("handler").WithValues("filename", "handler.go")
 
 // WebhookHandler manages the calls from github
 func WebhookHandler(w http.ResponseWriter, r *http.Request, reconciler gitopsconfig.Reconciler) {

--- a/pkg/handler/handler.go
+++ b/pkg/handler/handler.go
@@ -41,7 +41,7 @@ func WebhookHandler(w http.ResponseWriter, r *http.Request, reconciler gitopscon
 
 	payload, err := ioutil.ReadAll(r.Body)
 	if err != nil {
-		log.Error(err, "error reading request body")
+		log.Error(err, "error reading webhook request body")
 		return
 	}
 	defer r.Body.Close()

--- a/pkg/handler/handler.go
+++ b/pkg/handler/handler.go
@@ -72,7 +72,7 @@ func WebhookHandler(w http.ResponseWriter, r *http.Request, reconciler gitopscon
 
 			for _, instance := range list.Items {
 				if !gitopsconfig.ContainsTrigger(&instance, "Webhook") {
-					log.Info("skip instance without webhook trigger", "instance_name", &instance.Name)
+					log.Info("skip instance without webhook trigger", "instance_name", instance.Name)
 					continue
 				}
 
@@ -81,11 +81,11 @@ func WebhookHandler(w http.ResponseWriter, r *http.Request, reconciler gitopscon
 					"parameter_uri", instance.Spec.ParameterSource.URI, "parameter_ref", instance.Spec.ParameterSource.Ref)
 
 				if !repoURLAndRefMatch(&instance, e) {
-					log.Info("skip instance without matching repo url or git ref of the event", "instance_name", &instance.Name)
+					log.Info("skip instance without matching repo url or git ref of the event", "instance_name", instance.Name)
 					continue
 				}
 
-				log.Info("found matching instance", "instance_name", &instance.Name)
+				log.Info("found matching instance", "instance_name", instance.Name)
 				targetList.Items = append(targetList.Items, instance)
 			}
 

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -32,7 +32,7 @@ import (
 
 var jobTemplate *template.Template
 var cronJobTemplate *template.Template
-var log = logf.Log.WithName("util")
+var log = logf.Log.WithName("util").WithValues("filename", "util.go")
 
 // JobMergeData is the structs that will be used to merge with the job template
 type JobMergeData struct {


### PR DESCRIPTION
**Description**

Logging improvements provide better clarity as to why a GitHub push
event did not trigger a reconsiliation job for each GitOpsConfigs.

A new check was also added to see if any GitOpsConfig match the webhook
event payload. If no GitOpsConfigs match we log there were no
GitOpsConfigs found and return. This prevents the log message stating
that we are reconciling a GitOpsConfig with an empty namespace and
empty GitOpsConfig name mentioned in issue #270:

```{"level":"info","ts":#,"logger":"gitopsconfig-controller","msg":"Reconciling GitOpsConfig","Request.Namespace":"","Request.Name":""}```

Fixes #270 

**Type of change**

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)

**Checklist**

- [ ] Unit tests and e2e tests updated
- [ ] ~Documentation updated~ n/a
