### PR TITLE
Fix unreliable webhook triggers

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -221,6 +221,7 @@ make test-unit
 # Optional: Set the environment variable $EUNOMIA_TEST_PAUSE to yes (default is no)
 # Optional: Set the environment variable $EUNOMIA_TEST_SKIP_IMAGES to yes to skip building all images
 # Optional: Set the environment variable $EUNOMIA_TEST_SKIP_DEPLOYMENT to yes to skip the Eunomia deployment
+# Optional: Set the environment variable $EUNOMIA_TEST_GO_RUN to the single test you want to run
 
 make test-e2e
 ```

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -219,6 +219,9 @@ make test-unit
 # Optional: Set the environment variable $EUNOMIA_REF to point to a specific git reference for testing
 # Optional: Set the environment variable $EUNOMIA_TEST_ENV to minishift (default is minikube)
 # Optional: Set the environment variable $EUNOMIA_TEST_PAUSE to yes (default is no)
+# Optional: Set the environment variable $EUNOMIA_TEST_SKIP_IMAGES to yes to skip building all images
+# Optional: Set the environment variable $EUNOMIA_TEST_SKIP_DEPLOYMENT to yes to skip the Eunomia deployment
+
 make test-e2e
 ```
 

--- a/pkg/controller/gitopsconfig/controller.go
+++ b/pkg/controller/gitopsconfig/controller.go
@@ -53,9 +53,6 @@ const (
 	controllerName string = "gitopsconfig-controller"
 )
 
-// PushEvents channel on which we get the github webhook push events
-var PushEvents = make(chan event.GenericEvent)
-
 // Add creates a new GitOpsConfig Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
 func Add(mgr manager.Manager) error {
@@ -104,14 +101,6 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 	)
 	if err != nil {
 		return fmt.Errorf("controller watch for changes to primary resource GitOpsConfig failed: %w", err)
-	}
-
-	err = c.Watch(
-		&source.Channel{Source: PushEvents},
-		&handler.EnqueueRequestForObject{},
-	)
-	if err != nil {
-		return fmt.Errorf("controller watch for PushEvents failed: %w", err)
 	}
 
 	// TODO: we should somehow detect when Reconciler is stopped, and run the

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -21,7 +21,7 @@ export OPERATOR_SDK_VERSION="v0.12.0"
 usage() {
     cat <<EOT
 e2e-test.sh [-e|--env=(minikube|minishift)] [-p|--pause] [-n|--noimages] 
-            [-d|--nodeployment] [-t|--test=<test name>]
+            [-d|--nodeployment] [-r|--run=<test name>]
 
 Execute the end-to-end tests on a local minikube or minishift.
 

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -131,7 +131,7 @@ while (("$#")); do
         ;;
     -e | --env) # set the test environment
         if [ -n "$2" ] && [ "${2:0:1}" != "-" ]; then
-            EUNOMIA_TEST_ENV=$2
+            export EUNOMIA_TEST_ENV=$2
             shift 2
         else
             echo "Error: Argument for $1 is missing" >&2
@@ -148,7 +148,7 @@ while (("$#")); do
         ;;
     -r | --run) # run specific go e2e test
         if [ -n "$2" ] && [ "${2:0:1}" != "-" ]; then
-            EUNOMIA_TEST_GO_RUN=$2
+            export EUNOMIA_TEST_GO_RUN=$2
             shift 2
         else
             echo "Error: Argument for $1 is missing" >&2

--- a/test/e2e/issue216_test.go
+++ b/test/e2e/issue216_test.go
@@ -81,7 +81,7 @@ func TestIssue216InvalidImageDeleted(t *testing.T) {
 
 	err = wait.Poll(retryInterval, timeout, func() (done bool, err error) {
 		const name = "gitopsconfig-gitops-issue216-"
-		pod, err := GetPod(ctx.namespace, name, "quay.io/kohlstechnology/invalid:bad", framework.Global.KubeClient)
+		pod, err := GetPod(t, ctx.namespace, name, "quay.io/kohlstechnology/invalid:bad", framework.Global.KubeClient)
 		switch {
 		case apierrors.IsNotFound(err):
 			t.Logf("Waiting for availability of %s pod", name)
@@ -134,7 +134,7 @@ func TestIssue216InvalidImageDeleted(t *testing.T) {
 
 	err = wait.Poll(retryInterval, timeout, func() (done bool, err error) {
 		const name = "gitopsconfig-gitops-issue216-"
-		pod, err := GetPod(ctx.namespace, name, "", framework.Global.KubeClient)
+		pod, err := GetPod(t, ctx.namespace, name, "", framework.Global.KubeClient)
 		switch {
 		case apierrors.IsNotFound(err):
 			t.Logf("Confirmed no more pods found")

--- a/test/e2e/issue276_test.go
+++ b/test/e2e/issue276_test.go
@@ -98,7 +98,7 @@ func TestIssue276NoTemplatesDir(t *testing.T) {
 
 	const name = "gitopsconfig-gitops-issue276-"
 	err = wait.Poll(retryInterval, timeout, func() (done bool, err error) {
-		pod, err := GetPod(ctx.namespace, name, "quay.io/kohlstechnology/eunomia-base:dev", framework.Global.KubeClient)
+		pod, err := GetPod(t, ctx.namespace, name, "quay.io/kohlstechnology/eunomia-base:dev", framework.Global.KubeClient)
 		switch {
 		case apierrors.IsNotFound(err):
 			t.Logf("Waiting for availability of %s pod", name)
@@ -195,7 +195,7 @@ func TestIssue276EmptyTemplatesDir(t *testing.T) {
 
 	err = wait.Poll(retryInterval, timeout, func() (done bool, err error) {
 		const name = "gitopsconfig-gitops-issue276-"
-		pod, err := GetPod(ctx.namespace, name, "quay.io/kohlstechnology/eunomia-base:dev", framework.Global.KubeClient)
+		pod, err := GetPod(t, ctx.namespace, name, "quay.io/kohlstechnology/eunomia-base:dev", framework.Global.KubeClient)
 		switch {
 		case apierrors.IsNotFound(err):
 			t.Logf("Waiting for availability of %s pod", name)

--- a/test/e2e/issue279_test.go
+++ b/test/e2e/issue279_test.go
@@ -112,7 +112,7 @@ func TestIssue279CronJobDeletion(t *testing.T) {
 	// Two minutes timeout to give cronjob enought time to kick off
 	err = wait.Poll(retryInterval, time.Second*120, func() (done bool, err error) {
 		const name = "gitopsconfig-gitops-issue279-"
-		pod, err := GetPod(namespace, name, "quay.io/kohlstechnology/eunomia-base:dev", framework.Global.KubeClient)
+		pod, err := GetPod(t, namespace, name, "quay.io/kohlstechnology/eunomia-base:dev", framework.Global.KubeClient)
 		switch {
 		case apierrors.IsNotFound(err):
 			t.Logf("Waiting for availability of %s pod", name)

--- a/test/e2e/probes_test.go
+++ b/test/e2e/probes_test.go
@@ -19,107 +19,20 @@ limitations under the License.
 package e2e
 
 import (
-	"context"
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"os"
-	"strconv"
 	"testing"
-
-	framework "github.com/operator-framework/operator-sdk/pkg/test"
-	util "github.com/operator-framework/operator-sdk/pkg/test/e2eutil"
-	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 func TestReadinessAndLivelinessProbes(t *testing.T) {
-	ctx := framework.NewTestCtx(t)
-	defer ctx.Cleanup()
-
-	operatorName, found := os.LookupEnv("OPERATOR_NAME")
-	if !found {
-		t.Fatal("OPERATOR_NAME environment value missing")
-	}
-	operatorNamespace, found := os.LookupEnv("OPERATOR_NAMESPACE")
-	if !found {
-		t.Fatal("OPERATOR_NAMESPACE environment value missing")
-	}
-	minikubeIP, found := os.LookupEnv("MINIKUBE_IP")
-	if !found {
-		t.Fatal("MINIKUBE_IP environment value missing")
-	}
-	webHookPort, found := os.LookupEnv("OPERATOR_WEBHOOK_PORT")
-	if !found {
-		t.Fatal("OPERATOR_WEBHOOK_PORT environment value missing")
-	}
-	webHookPortInt, err := strconv.Atoi(webHookPort)
+	ctx, err := NewContext(t)
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer ctx.Cleanup()
 
-	t.Logf("minikube IP: %s", minikubeIP)
-
-	// The aim of this test is to validate that the required endpoints are there and are accessible. To
-	// achieve this, we need to expose the deployment externally outside of minikube as this test runs
-	// outside of it. To ensure that this is done correctly, a Service with Type: "NodePort" is created,
-	// to expose the operator's webhook via high, random port.
-	service := &corev1.Service{
-		TypeMeta: v1.TypeMeta{
-			Kind:       "Service",
-			APIVersion: "v1",
-		},
-		ObjectMeta: v1.ObjectMeta{
-			Name:      "minikube-exposing-service",
-			Namespace: operatorNamespace,
-		},
-		Spec: corev1.ServiceSpec{
-			Ports: []corev1.ServicePort{
-				{
-					Name:     "webhook",
-					Protocol: corev1.ProtocolTCP,
-					Port:     int32(webHookPortInt),
-					TargetPort: intstr.IntOrString{
-						Type:   intstr.Int,
-						IntVal: int32(webHookPortInt),
-					},
-				},
-			},
-			Selector: map[string]string{"name": operatorName},
-			Type:     "NodePort",
-		},
-	}
-
-	err = framework.Global.Client.Create(context.TODO(), service, &framework.CleanupOptions{
-		TestContext:   ctx,
-		Timeout:       timeout,
-		RetryInterval: retryInterval,
-	})
-	if err != nil {
-		t.Error(err)
-	}
-	nodePort := service.Spec.Ports[0].NodePort
-
-	t.Logf("minikube exposing service Node Port: %d", nodePort)
-
-	err = util.WaitForOperatorDeployment(t, framework.Global.KubeClient, operatorNamespace, operatorName, 1, retryInterval, timeout)
-	if err != nil {
-		t.Error(err)
-	}
-
-	//Waiting for service to get connection to operator pod
-	for retryCount := 0; retryCount < 50; retryCount++ {
-		t.Logf("retrying %d", retryCount)
-		resp, err := http.Get(fmt.Sprintf("http://%s:%d/readyz", minikubeIP, nodePort))
-		if err != nil {
-			t.Log(err)
-			continue
-		}
-		if resp.StatusCode == http.StatusOK {
-			break
-		}
-	}
+	hostUrl := ExposeOperatorAsService(t, ctx)
 
 	tests := []struct {
 		endpoint string
@@ -133,7 +46,7 @@ func TestReadinessAndLivelinessProbes(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		resp, err := http.Get(fmt.Sprintf("http://%s:%d/%s", minikubeIP, nodePort, tt.endpoint))
+		resp, err := http.Get(fmt.Sprintf("%s/%s", hostUrl, tt.endpoint))
 		if err != nil {
 			t.Errorf("%q: %s", tt.endpoint, err)
 			continue

--- a/test/e2e/status_test.go
+++ b/test/e2e/status_test.go
@@ -113,7 +113,7 @@ func TestStatusSuccess(t *testing.T) {
 
 	// Step 3: verify that the pod exists
 
-	pod, err := GetPod(ctx.namespace, "hello-test-a", "hello-app:1.0", framework.Global.KubeClient)
+	pod, err := GetPod(t, ctx.namespace, "hello-test-a", "hello-app:1.0", framework.Global.KubeClient)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -222,7 +222,7 @@ func TestStatusPeriodicJobSuccess(t *testing.T) {
 
 	// Step 3: verify that the pod exists
 
-	pod, err := GetPod(ctx.namespace, "hello-test-b", "hello-app:1.0", framework.Global.KubeClient)
+	pod, err := GetPod(t, ctx.namespace, "hello-test-b", "hello-app:1.0", framework.Global.KubeClient)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -24,18 +24,24 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"net/http"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
 
 	framework "github.com/operator-framework/operator-sdk/pkg/test"
+	e2eutil "github.com/operator-framework/operator-sdk/pkg/test/e2eutil"
 	batchv1beta1 "k8s.io/api/batch/v1beta1"
+	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 
@@ -176,7 +182,7 @@ func WaitForPodAbsence(t *testing.T, f *framework.Framework, namespace, name, im
 	return nil
 }
 
-// WaitForPodWithImageAndStatus retrieves a pod using GetPod and waits for it to be running and available
+// WaitForPodsWithStatus wait for a list of pods with the status specified
 func WaitForPodsWithStatus(t *testing.T, f *framework.Framework, namespace string, pods []podWatchList, status string, retryInterval, timeout time.Duration) error {
 	for _, pod := range pods {
 		err := WaitForPodWithImageAndStatus(t, f, namespace, pod.name, pod.image, status, retryInterval, timeout)
@@ -280,4 +286,86 @@ func SetupRbacInNamespace(namespace string) error {
 	}
 
 	return nil
+}
+
+// ExposeOperatorAsService exposes the deployment externally outside of minikube to allow API test to run.
+// To ensure that this is done correctly, a Service with Type: "NodePort" is created,
+// to expose the operator's webhook via high, random port.
+func ExposeOperatorAsService(t *testing.T, ctx *Context) string {
+	operatorName, found := os.LookupEnv("OPERATOR_NAME")
+	if !found {
+		t.Fatal("OPERATOR_NAME environment value missing")
+	}
+	operatorNamespace, found := os.LookupEnv("OPERATOR_NAMESPACE")
+	if !found {
+		t.Fatal("OPERATOR_NAMESPACE environment value missing")
+	}
+	minikubeIP, found := os.LookupEnv("MINIKUBE_IP")
+	if !found {
+		t.Fatal("MINIKUBE_IP environment value missing")
+	}
+	webHookPort, found := os.LookupEnv("OPERATOR_WEBHOOK_PORT")
+	if !found {
+		t.Fatal("OPERATOR_WEBHOOK_PORT environment value missing")
+	}
+	webHookPortInt, err := strconv.Atoi(webHookPort)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Logf("minikube IP: %s", minikubeIP)
+
+	service := &corev1.Service{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Service",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "minikube-exposing-service",
+			Namespace: operatorNamespace,
+		},
+		Spec: corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{
+				{
+					Name:     "webhook",
+					Protocol: corev1.ProtocolTCP,
+					Port:     int32(webHookPortInt),
+					TargetPort: intstr.IntOrString{
+						Type:   intstr.Int,
+						IntVal: int32(webHookPortInt),
+					},
+				},
+			},
+			Selector: map[string]string{"name": operatorName},
+			Type:     "NodePort",
+		},
+	}
+
+	err = framework.Global.Client.Create(goctx.TODO(), service, &framework.CleanupOptions{TestContext: ctx.TestCtx, Timeout: timeout, RetryInterval: retryInterval})
+	if err != nil {
+		t.Error(err)
+	}
+	nodePort := service.Spec.Ports[0].NodePort
+
+	t.Logf("minikube exposing service Node Port: %d", nodePort)
+
+	err = e2eutil.WaitForOperatorDeployment(t, framework.Global.KubeClient, operatorNamespace, operatorName, 1, retryInterval, timeout)
+	if err != nil {
+		t.Error(err)
+	}
+
+	//Waiting for service to get connection to operator pod
+	for retryCount := 0; retryCount < 50; retryCount++ {
+		t.Logf("retrying %d", retryCount)
+		resp, err := http.Get(fmt.Sprintf("http://%s:%d/readyz", minikubeIP, nodePort))
+		if err != nil {
+			t.Log(err)
+			continue
+		}
+		if resp.StatusCode == http.StatusOK {
+			t.Logf("Operator available via service on %s", fmt.Sprintf("http://%s:%d/readyz", minikubeIP, nodePort))
+			break
+		}
+	}
+	return fmt.Sprintf("http://%s:%d", minikubeIP, nodePort)
 }


### PR DESCRIPTION
**Description**

This pull request fixes the issue with unreliable webhook triggers.

Using GenericEvents and a channel produces inconsistent results. Most OSS operators don't implement this functionality. Switching back to creating the gitopsconfig job directly (Which is the same the reconciler would do, except this works consistently).

Fixes #336 

This PR also adds 2 new parameters to `scripts/e2e-test.sh` in order to speed up local testing cycles:
```
-d|--nodeployment Skip the deployment of the operator
-n|--noimages Skip building the images
-r|--run=<test name> Only run the specified Go e2e test. This will skip all others.
```

**Type of change**

* Bug fix (non-breaking change which fixes an issue)

**Checklist**

- [X] Unit tests and e2e tests updated
- [X] Documentation updated
