### PR TITLE
Remove superfluous message about unstarted jobs

### DIFF
--- a/pkg/controller/gitopsconfig/status_updater.go
+++ b/pkg/controller/gitopsconfig/status_updater.go
@@ -62,8 +62,9 @@ func (u *statusUpdater) OnUpdate(oldObj, newObj interface{}) {
 	if newJob == nil {
 		newJob = oldJob
 	}
+
 	if newJob.Status.StartTime == nil {
-		log.Info("unstarted Job found; cannot properly set GitOpsConfig.Status based on it, ignoring", "job", newJob.Name)
+		// Unstarted Job found; cannot properly set GitOpsConfig.Status based on it, ignoring
 		return
 	}
 


### PR DESCRIPTION
**Description**
gitopsconfig: remove superfulous message from status updater when job has not been starter

The status updater was was putting out a message that it can not update the gitopsconfig of an unstarted job.  This message is not needed.  Once the job starts the gitopsconfig gets updated with the appropriate information.

Fixes #305 

* Bug fix (non-breaking change which fixes an issue)

**Checklist**

- [ ] Unit tests and e2e tests updated
- [ ] Documentation updated
