### PR TITLE
Add Ability To Set Service .spec.type

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,7 +326,7 @@ helm template deploy/helm/eunomia-operator/ | kubectl apply -f -
 
 #### Installing with Kubernetes Ingress
 
-Update [values.yaml](deploy/helm/eunomia-operator/values.yaml) file for ingress configuration. If you doesn't want to change the file we can enabled ingress from command line as well.
+Update [values.yaml](deploy/helm/eunomia-operator/values.yaml) file for ingress configuration. If you don't want to change the file, you can enable ingress from command line as well.
 
 For running with default configuration
 
@@ -348,6 +348,20 @@ helm template deploy/helm/eunomia-operator/ --set eunomia.operator.ingress.enabl
 ```
 
 Replace the host `hello-eunomia.info` with suitable DNS name.
+
+#### Installing with Cloud Load Balancers
+
+Update [values.yaml](deploy/helm/eunomia-operator/values.yaml) file for the service configuration. If you don't want to change the file, you can enable ingress from command line as well.
+
+For running with default configuration
+
+```shell
+# Enabling eunomia with cloud load balancer
+helm template deploy/helm/eunomia-operator/ \
+  --set eunomia.operator.service.type=LoadBalancer \
+  --set eunomia.operator.service.annotations."cloud\.google\.com\/load-balancer-type"=Internal \
+  | kubectl apply -f - -n eunomia-operator
+```
 
 ### Installing on OpenShift
 

--- a/deploy/helm/eunomia-operator/templates/service.yaml
+++ b/deploy/helm/eunomia-operator/templates/service.yaml
@@ -6,6 +6,9 @@ metadata:
   annotations:
     prometheus.io/scrape: 'true'
     prometheus.io/port: '8383'
+    {{- with .service.annotations }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
   name: eunomia-operator
   namespace: "{{ .namespace }}"
 spec:
@@ -20,5 +23,9 @@ spec:
     port: 8383
     protocol: TCP
     targetPort: 8383
+  sessionAffinity: None
+{{- if .service.type }}
+  type: {{ .service.type }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/deploy/helm/eunomia-operator/values.yaml
+++ b/deploy/helm/eunomia-operator/values.yaml
@@ -35,6 +35,14 @@ eunomia:
       #    hosts:
       #      - chart-example.local
 
+    service:
+      # Enable the below setting to expose the service through a cloud load balancer
+      annotations: {}
+        # cloud.google.com/load-balancer-type: "Internal"
+        # service.beta.kubernetes.io/aws-load-balancer-internal: "true"
+        # service.beta.kubernetes.io/azure-load-balancer-internal: "true"
+      #type: LoadBalancer
+
     nodeSelector: {}
 
     tolerations: []


### PR DESCRIPTION
**Description**

You can now specify the service type as part of the operator installation. This allows to e.g. set it to `LoadBalancer` to enable cloud native load balancers. This will require setting the correct annotations for your cloud provider. Some examples have been provided in the default `values.yml`.

Fixes #328 

**Type of change**

* New feature (non-breaking change which adds functionality)

**Checklist**

- [ ] Unit tests and e2e tests updated
- [X] Documentation updated
