### PR TITLE
Increase CPU limit to 1 to support heavier template processing

### DIFF
--- a/build/job-templates/cronjob.yaml
+++ b/build/job-templates/cronjob.yaml
@@ -99,7 +99,7 @@ spec:
                 cpu: '200m'
                 memory: '256Mi'
               limits:
-                cpu: '200m'
+                cpu: '1'
                 memory: '256Mi'
           volumes:
           - name: workspace

--- a/build/job-templates/job.yaml
+++ b/build/job-templates/job.yaml
@@ -98,7 +98,7 @@ spec:
             cpu: '200m'
             memory: '256Mi'
           limits:
-            cpu: '200m'
+            cpu: '1'
             memory: '256Mi'
       volumes:
       - name: workspace


### PR DESCRIPTION
**Description**

Complex helm charts take forever to process. This change allows the pod to take up to 1 CPU (limit), but leaves the request at 200m.

**Type of change**

* Bug fix (non-breaking change which fixes an issue)

**Checklist**

- [ ] Unit tests and e2e tests updated
- [ ] Documentation updated
