### PR TITLE
Remove resource deletion race condition between jobs

### DIFF
--- a/template-processors/base/Dockerfile
+++ b/template-processors/base/Dockerfile
@@ -4,7 +4,7 @@ ENV USER_UID=1001 \
     USER_NAME=gitopsjob \
     kubectl=kubectl \
     KUBECTL_VERSION="v1.19.5" \
-    YQ_VERSION="2.7.2" \
+    YQ_VERSION="2.11.1" \
     GOLANG_YQ_VERSION="3.3.2" \
     JQ_VERSION="1.6"
 

--- a/template-processors/base/Dockerfile
+++ b/template-processors/base/Dockerfile
@@ -8,7 +8,6 @@ ENV USER_UID=1001 \
     GOLANG_YQ_VERSION="3.3.2" \
     JQ_VERSION="1.6"
 
-COPY bin /usr/local/bin
 
 RUN yum install -y --disableplugin=subscription-manager git gettext python36-devel gcc python3-pip python3-setuptools && \
     curl https://github.com/stedolan/jq/releases/download/jq-${JQ_VERSION}/jq-linux64 -L -o /usr/bin/jq && \
@@ -17,8 +16,11 @@ RUN yum install -y --disableplugin=subscription-manager git gettext python36-dev
     chmod +x /usr/bin/kubectl && \
     pip3 install yq==${YQ_VERSION} && \
     curl -L https://github.com/mikefarah/yq/releases/download/${GOLANG_YQ_VERSION}/yq_linux_amd64 -o /usr/bin/goyq && \
-    chmod +x /usr/bin/goyq && \
-    /usr/local/bin/user_setup
+    chmod +x /usr/bin/goyq
+
+COPY bin /usr/local/bin
+
+RUN /usr/local/bin/user_setup
 
 ENTRYPOINT ["/usr/local/bin/entrypoint"]
 

--- a/template-processors/base/bin/appendResourceVersion.py
+++ b/template-processors/base/bin/appendResourceVersion.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+
+# Copyright 2020 Kohl's Department Stores, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import yaml
+
+# appendResourceVersion - patches the YAML&JSON files in $MANIFEST_DIR,
+# adding the metadata.resourceVersion for each resource being managed.
+# This is intended to serve as a locking mechanism when applying resources
+# in which Kubernetes will fail the apply with a StatusConflict (HTTP status code 409)
+# Ref https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+#
+# Inputs:
+#
+# MANIFEST_DIR environment variable
+
+if __name__ == "__main__":
+    logging.basicConfig(stream=sys.stdout, level=logging.INFO)
+    logging.info("starting appendResourceVersion")
+    manifest_dir = os.getenv('MANIFEST_DIR')
+    with open('/var/run/secrets/kubernetes.io/serviceaccount/token') as x: token = x.read()
+    files = list(Path(manifest_dir).rglob("*.yml")) + list(Path(manifest_dir).rglob("*.yaml")) + list(Path(manifest_dir).rglob("*.json"))
+    for filename in files:
+        logging.info("processing file {}".format(filename))
+        try:
+            data = yaml.safe_load(subprocess.run(["kubectl",
+                "-s",
+                "https://kubernetes.default.svc:443",
+                "--token",
+                token,
+                "--certificate-authority",
+                "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt",
+                "get",
+                "--ignore-not-found",
+                "-f",
+                filename,
+                "-o",
+                "yaml"], stdout=subprocess.PIPE).stdout)
+            if data is None:
+                logging.error("no kubectl get output for file {}".format(filename))
+                continue
+            if "kind" in data and data["kind"] == "List":
+                logging.info("file {} contains a list".format(filename))
+                if "items" not in data:
+                    logging.info("file {} has list with zero items".format(filename))
+                    continue
+                resource_version = {}
+                for item in data["items"]:
+                    if "metadata" in item and "resourceVersion" in item["metadata"]:
+                        gvk_name = item["apiVersion"] + item["kind"] + item["metadata"]["name"]
+                        resource_version[gvk_name] = item["metadata"]["resourceVersion"]
+                        logging.info("got resource version {} for {}".format(item["metadata"]["resourceVersion"], gvk_name))
+                    else:
+                        logging.error("failed to get resource version for file {}".format(filename))
+                        continue
+                with open(filename, 'r+') as stream:
+                    try:
+                        new_docs = []
+                        docs = yaml.safe_load_all(stream)
+                        for doc in docs:
+                            gvk_name = doc["apiVersion"] + doc["kind"] + doc["metadata"]["name"]
+                            if gvk_name in resource_version:
+                                doc["metadata"]["resourceVersion"] = resource_version[gvk_name]
+                            else:
+                                logging.error("failed to patch resource version for {} in file {}".format(gvk_name, filename))
+                            new_docs.append(doc)
+                        stream.seek(0)
+                        stream.truncate()
+                        yaml.safe_dump_all(new_docs, stream, explicit_start=True)
+                    except yaml.YAMLError as exc:
+                        logging.error("fatal error", exc_info=True)
+            else:
+                logging.info("file {} contains a {}".format(filename, data["kind"]))
+                if "metadata" in data and "resourceVersion" in data["metadata"]:
+                    with open(filename, 'r+') as stream:
+                        try:
+                            with_resource_version = yaml.safe_load(stream)
+                            logging.info("got resource version {} for file {}".format(data["metadata"]["resourceVersion"], filename))
+                            with_resource_version["metadata"]["resourceVersion"] = data["metadata"]["resourceVersion"]
+                            stream.seek(0)
+                            stream.truncate()
+                            yaml.safe_dump(with_resource_version, stream)
+                        except yaml.YAMLError as exc:
+                            logging.error("fatal error", exc_info=True)
+                else:
+                    logging.error("failed to patch resource version for file {}".format(filename))
+        except yaml.YAMLError as exc:
+            logging.error("fatal error", exc_info=True)

--- a/template-processors/base/bin/appendResourceVersion.py
+++ b/template-processors/base/bin/appendResourceVersion.py
@@ -59,7 +59,7 @@ if __name__ == "__main__":
                 continue
             if "kind" in data and data["kind"] == "List":
                 logging.info("file {} contains a list".format(filename))
-                if "items" not in data:
+                if "items" in data and len(data["items"]) == 0:
                     logging.info("file {} has list with zero items".format(filename))
                     continue
                 resource_version = {}

--- a/template-processors/base/bin/resourceManager.sh
+++ b/template-processors/base/bin/resourceManager.sh
@@ -54,6 +54,39 @@ function addLabels() {
     done
 }
 
+# appendResourceVersion - patches the YAML&JSON files in $MANIFEST_DIR,
+# adding the metadata.resourceVersion for each resource being managed.
+# This is intended to serve as a locking mechanism when applying resources
+# in which Kubernetes will fail the apply with a StatusConflict (HTTP status code 409)
+# Ref https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+function appendResourceVersion() {
+    local tmpdir="$(mktemp -d)"
+    mkdir -p "$tmpdir/$MANIFEST_DIR"
+    mkdir -p "$tmpdir/processed_files/$MANIFEST_DIR"
+    # shellcheck disable=SC2044
+    for file in $(find "$MANIFEST_DIR" -regextype posix-extended -iregex '.*\.(ya?ml|json)'); do
+        kube get --ignore-not-found -f "$file" -o yaml >"$tmpdir/$file"
+        local kind="$(cat "$tmpdir"/"$file" | yq -y .kind)"
+        if [[ "$kind" =~ "List" ]]; then
+            #TODO: figure out how to handle this
+            echo "THIS IS A LIST"
+        else
+            echo "THIS IS A $kind"
+            local resourceVersion="$(cat "$tmpdir"/"$file" | yq -y .metadata.resourceVersion)"
+            if [[ "${resourceVersion}" ]]; then
+                cat "$file" |
+                    yq -y -s "map(select(.!=null)|setpath([\"metadata\",\"resourceVersion\"]; \"$resourceVersion\"))|.[]" \
+                        >"$tmpdir/labeled"
+
+                cat "$tmpdir/labeled" >"$tmpdir/processed_files/$file"
+            else
+                echo "NO RESOURCE VERSION TO PATCH"
+                cat "$file" >"$tmpdir/processed_files/$file"
+            fi
+        fi
+    done
+}
+
 # deleteByOldLabels OWNER [TIMESTAMP] - deletes all kubernetes resources which have
 # the OWNER label as provided [optional: but TIMESTAMP label different than provided].
 function deleteByOldLabels() {
@@ -119,6 +152,7 @@ function createUpdateResources() {
     case "$CREATE_MODE" in
     Apply)
         addLabels "$owner" "$timestamp"
+        appendResourceVersion
         kube apply -R -f "$MANIFEST_DIR"
         deleteByOldLabels "$owner" "$timestamp"
         ;;

--- a/template-processors/base/bin/resourceManager.sh
+++ b/template-processors/base/bin/resourceManager.sh
@@ -65,6 +65,7 @@ function appendResourceVersion() {
     mkdir -p "$tmpdir/processed_files/$MANIFEST_DIR"
     # shellcheck disable=SC2044
     for file in $(find "$MANIFEST_DIR" -regextype posix-extended -iregex '.*\.(ya?ml|json)'); do
+        mkdir -p "$tmpdir"/"$(dirname "$file")"
         kube get --ignore-not-found -f "$file" -o yaml >"$tmpdir/$file"
         local kind="$(cat "$tmpdir"/"$file" | yq -y .kind)"
         if [[ "$kind" =~ "List" ]]; then
@@ -81,6 +82,7 @@ function appendResourceVersion() {
                 cat "$tmpdir/labeled" >"$tmpdir/processed_files/$file"
             else
                 echo "NO RESOURCE VERSION TO PATCH"
+                mkdir -p "$tmpdir"/processed_files/"$(dirname "$file")"
                 cat "$file" >"$tmpdir/processed_files/$file"
             fi
         fi

--- a/template-processors/base/bin/resourceManager.sh
+++ b/template-processors/base/bin/resourceManager.sh
@@ -66,6 +66,7 @@ function appendResourceVersion() {
     # shellcheck disable=SC2044
     for file in $(find "$MANIFEST_DIR" -regextype posix-extended -iregex '.*\.(ya?ml|json)'); do
         mkdir -p "$tmpdir"/"$(dirname "$file")"
+        mkdir -p "$tmpdir"/processed_files/"$(dirname "$file")"
         kube get --ignore-not-found -f "$file" -o yaml >"$tmpdir/$file"
         local kind="$(cat "$tmpdir"/"$file" | yq -y .kind)"
         if [[ "$kind" =~ "List" ]]; then
@@ -82,7 +83,6 @@ function appendResourceVersion() {
                 cat "$tmpdir/labeled" >"$tmpdir/processed_files/$file"
             else
                 echo "NO RESOURCE VERSION TO PATCH"
-                mkdir -p "$tmpdir"/processed_files/"$(dirname "$file")"
                 cat "$file" >"$tmpdir/processed_files/$file"
             fi
         fi

--- a/template-processors/openshift-provision/Dockerfile.in
+++ b/template-processors/openshift-provision/Dockerfile.in
@@ -5,7 +5,6 @@ USER root
 ENV OC_VERSION="4.6" \
     OPENSHIFT_PROVISION_COMMIT="2be5a143d928dbdcaa036fd89043fd99803fba98"
 
-COPY bin /usr/local/bin/
 COPY files /files
 
 RUN curl -O http://mirror.openshift.com/pub/openshift-v4/clients/oc/${OC_VERSION}/linux/oc.tar.gz && \
@@ -13,5 +12,7 @@ RUN curl -O http://mirror.openshift.com/pub/openshift-v4/clients/oc/${OC_VERSION
     git clone https://github.com/KohlsTechnology/ansible-role-openshift-provision.git /files/roles/openshift-provision && \
     git -C /files/roles/openshift-provision checkout ${OPENSHIFT_PROVISION_COMMIT} && \
     pip3 install -r /files/requirements.txt
+
+COPY bin /usr/local/bin/
 
 USER ${USER_UID}


### PR DESCRIPTION
**Description**

Utilize the `metadata.resourceVersion` field in k8s manifests to prevent multiple concurrent jobs from overwriting resources. This is being done because the resource deletion logic relies on owner and timestamp labels, and if there is a conflict in the labels because of concurrent jobs, resources could be unexpectedly deleted.

The solution was based on the Kubernetes documentation around concurrency: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency

Fixes #370 

There are also small ordering tweaks to the `base` and `openshift-provision` templates to reduce image build times while making changes to the scripts in the template processors.

**Type of change**

* Bug fix (non-breaking change which fixes an issue)

**Checklist**

- [ ] Unit tests and e2e tests updated
- [x] Documentation updated
- [x] Update code to handle single files with multiple resources defined
