### PR TITLE
Add pip upgrade to applier and openshift-provision template processors

### DIFF
--- a/template-processors/applier/Dockerfile.in
+++ b/template-processors/applier/Dockerfile.in
@@ -4,7 +4,8 @@ ENV OPENSHIFT_MODULE_VERSION=0.9.0
 ENV KUBE_MODULE_VERSION=9.0.0
 
 USER root
-
+#Upgrade pip before other pip installs to avoid issue with setuptools-rust
+RUN pip3 install --upgrade pip
 RUN yum install -y --disableplugin=subscription-manager python36-devel gcc python3-pip python3-setuptools && \
     pip3 install ansible openshift==$OPENSHIFT_MODULE_VERSION kubernetes==$KUBE_MODULE_VERSION jmespath passlib && \
     yum remove -y gcc python36-devel

--- a/template-processors/openshift-provision/Dockerfile.in
+++ b/template-processors/openshift-provision/Dockerfile.in
@@ -6,7 +6,8 @@ ENV OC_VERSION="4.6" \
     OPENSHIFT_PROVISION_COMMIT="2be5a143d928dbdcaa036fd89043fd99803fba98"
 
 COPY files /files
-
+#Upgrade pip before other pip installs to avoid issue with setuptools-rust
+RUN pip3 install --upgrade pip
 RUN curl -O http://mirror.openshift.com/pub/openshift-v4/clients/oc/${OC_VERSION}/linux/oc.tar.gz && \
     tar --directory /usr/bin -zxvf oc.tar.gz oc && \
     git clone https://github.com/KohlsTechnology/ansible-role-openshift-provision.git /files/roles/openshift-provision && \


### PR DESCRIPTION
<!--
    Please read https://github.com/KohlsTechnology/eunomia/blob/master/.github/CONTRIBUTING.md before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**
Add pip upgrade to applier and openshift-provision template processors to avoid setuptools-rust error from ansible module dependency.

<!-- Please provide a summary of the change here. -->

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #ISSUE

**Type of change**

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)

**Checklist**

- [ ] Unit tests and e2e tests updated
- [ ] Documentation updated
