### PR TITLE
deploy/helm: add option to create PodSecurityPolicy

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,62 +320,13 @@ This field specifies how to handle resources when the GitOpsConfig object is del
 
 ## Installing Eunomia
 
-### Installing on Kubernetes
+### Installing on Kubernetes Using Helm
 
-Simply use the helm chart to install it on your flavor of Kubernetes.
+See the [helm README](deploy/helm/eunomia-operator/README.md) for details.
 
-```shell
-# Deploy the operator
-helm template deploy/helm/eunomia-operator/ | kubectl apply -f -
-```
+### Installing on Kubernetes Using Operator Hub
 
-#### Installing with Kubernetes Ingress
-
-Update [values.yaml](deploy/helm/eunomia-operator/values.yaml) file for ingress configuration. If you don't want to change the file, you can enable ingress from command line as well.
-
-For running with default configuration
-
-```shell
-# Enabling eunomia ingress
-helm template deploy/helm/eunomia-operator/ --set eunomia.operator.ingress.enabled=true | kubectl apply -f - -n eunomia-operator
-```
-
-Also, you can pass the ingress configuration in command line itself. For example:-
-
-```shell
-# Updating eunomia ingress configuration
-helm template deploy/helm/eunomia-operator/ --set eunomia.operator.ingress.enabled=true \
---set eunomia.operator.ingress.hosts[0].host=hello-eunomia.info \
---set eunomia.operator.ingress.hosts[0].paths[0].path=/ \
---set eunomia.operator.ingress.hosts[0].paths[0].portName=webhook \
---set eunomia.operator.ingress.hosts[0].paths[1].path=/metrics \
---set eunomia.operator.ingress.hosts[0].paths[1].portName=metrics | kubectl apply -f - -n eunomia-operator
-```
-
-Replace the host `hello-eunomia.info` with suitable DNS name.
-
-#### Installing with Cloud Load Balancers
-
-Update [values.yaml](deploy/helm/eunomia-operator/values.yaml) file for the service configuration. If you don't want to change the file, you can enable ingress from command line as well.
-
-For running with default configuration
-
-```shell
-# Enabling eunomia with cloud load balancer
-helm template deploy/helm/eunomia-operator/ \
-  --set eunomia.operator.service.type=LoadBalancer \
-  --set eunomia.operator.service.annotations."cloud\.google\.com\/load-balancer-type"=Internal \
-  | kubectl apply -f - -n eunomia-operator
-```
-
-### Installing on OpenShift
-
-Use the below command to install Eunomia on OpenShift. This will also give you the route for the ingress webhook.
-
-```shell
-# Deploy the operator
-helm template deploy/helm/eunomia-operator/ --set eunomia.operator.openshift.route.enabled=true | oc apply -f -
-```
+See the [getting started document](GETTING_STARTED.md#install-eunomia-from-operatorhub) for details.
 
 ## Examples / Demos
 

--- a/deploy/helm/eunomia-operator/README.md
+++ b/deploy/helm/eunomia-operator/README.md
@@ -1,0 +1,144 @@
+# Eunomia GitOps Operator for Kubernetes
+
+<!---
+This doesn't work yet. Maybe someday it will.
+
+## TL;DR:
+
+```shell
+helm repo add eunomia-operator https://kohlstechnology.github.io/eunomia/
+helm install my-release eunomia-operator/eunomia-operator
+```
+
+-->
+
+## Introduction
+
+This chart bootstraps a eunomia operator deployment on [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+
+## Prerequisites
+
+- Kubernetes 1.16+
+
+## Installing the Chart
+
+This command deploys _eunomia_ on a Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
+
+```shell
+# Deploy the operator
+helm template deploy/helm/eunomia-operator/ | kubectl apply -f -
+```
+
+### Installing with Kubernetes Ingress
+
+Update [values.yaml](values.yaml) file for ingress configuration. If you don't want to change the file, you can enable ingress from command line as well.
+
+For running with default configuration
+
+```shell
+# Enabling eunomia ingress
+helm template deploy/helm/eunomia-operator/ --set eunomia.operator.ingress.enabled=true | kubectl apply -f - -n eunomia-operator
+```
+
+Also, you can pass the ingress configuration in command line itself. For example:-
+
+```shell
+# Updating eunomia ingress configuration
+helm template deploy/helm/eunomia-operator/ --set eunomia.operator.ingress.enabled=true \
+--set eunomia.operator.ingress.hosts[0].host=hello-eunomia.info \
+--set eunomia.operator.ingress.hosts[0].paths[0].path=/ \
+--set eunomia.operator.ingress.hosts[0].paths[0].portName=webhook \
+--set eunomia.operator.ingress.hosts[0].paths[1].path=/metrics \
+--set eunomia.operator.ingress.hosts[0].paths[1].portName=metrics | kubectl apply -f - -n eunomia-operator
+```
+
+Replace the host `hello-eunomia.info` with suitable DNS name.
+
+### Installing with Cloud Load Balancers
+
+Update [values.yaml](values.yaml) file for the service configuration. If you don't want to change the file, you can enable ingress from command line as well.
+
+For running with default configuration
+
+```shell
+# Enabling eunomia with cloud load balancer
+helm template deploy/helm/eunomia-operator/ \
+  --set eunomia.operator.service.type=LoadBalancer \
+  --set eunomia.operator.service.annotations."cloud\.google\.com\/load-balancer-type"=Internal \
+  | kubectl apply -f - -n eunomia-operator
+```
+
+### Installing with PSP
+
+```shell
+# Enabling eunomia PodSecurityPolicy
+helm template deploy/helm/eunomia-operator/ --set eunomia.operator.podSecurityPolicy.enabled=true | kubectl apply -f - -n eunomia-operator
+```
+
+### Installing on OpenShift
+
+Use the below command to install Eunomia on OpenShift. This will also give you the route for the ingress webhook.
+
+```shell
+# Deploy the operator
+helm template deploy/helm/eunomia-operator/ --set eunomia.operator.openshift.route.enabled=true | oc apply -f -
+```
+
+<!---
+This doesn't work yet. Maybe someday it will.
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```shell
+helm install my-release eunomia-operator/eunomia-operator
+```
+
+The command deploys _eunomia_ on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
+
+> **Tip**: List all releases using `helm list`
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` deployment:
+
+```shell
+helm delete my-release
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+-->
+
+## Configuration
+
+The following table lists the configurable parameters of the _eunomia_ chart and their default values.
+
+| Parameter                                    | Description                                                                                                           | Default                              |
+| -------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- | ------------------------------------ |
+| `eunomia.operator.affinity`                  | Set `affinity` field in operator pod spec                                                                             | `nil`                                |
+| `eunomia.operator.deployment.clusterViewer`  | Create eunomia-cluster-list ClusterRole                                                                               | `true`                               |
+| `eunomia.operator.deployment.enabled`        | Create operator Deployment                                                                                            | `true`                               |
+| `eunomia.operator.deployment.nsRbacOnly`     | Only create RBAC objects                                                                                              | `false`                              |
+| `eunomia.operator.deployment.operatorHub`    | Do not create objects managed by OperatorHub install                                                                  | `false`                              |
+| `eunomia.operator.image.name`                | Operator container image name                                                                                         | `kohlstechnology/eunomia-operator`   |
+| `eunomia.operator.image.pullPolicy`          | Operator container image pull policy                                                                                  | `Always`                             |
+| `eunomia.operator.image.repository`          | Operator container image registry name                                                                                | `quay.io`                            |
+| `eunomia.operator.image.tag`                 | Operator contianer image tag                                                                                          | `latest`                             |
+| `eunomia.operator.ingress.annotations`       | Set .metadata.annotaions for Ingress                                                                                  | `nil`                                |
+| `eunomia.operator.ingress.enabled`           | Create Ingress for operator webhook                                                                                   | `false`                              |
+| `eunomia.operator.ingress.hosts`             | Set Ingress .spec.rules                                                                                               | _see values.yaml_                    |
+| `eunomia.operator.ingress.tls`               | Set Ingress .spec.tls                                                                                                 | `nil`                                |
+| `eunomia.operator.namespace`                 | Namespace for operator deployment                                                                                     | `eunomia-operator`                   |
+| `eunomia.operator.nodeSelector`              | Set `nodeSelector` in operator pod spec                                                                               | `nil`                                |
+| `eunomia.operator.openshift.enabled`         | If `true`, enable installation on OpenShift                                                                           | `false`                              |
+| `eunomia.operator.openshift.route.enabled`   | If `true`, create OpenShift Route                                                                                     | `false`                              |
+| `eunomia.operator.podSecurityPolicy.enabled` | If `true`, create PodSecurityPolicy and RBAC resources                                                                | `false`                              |
+| `eunomia.operator.replicas`                  | Operator Deploy .spec.replicas                                                                                        | `1`                                  |
+| `eunomia.operator.resources`                 | Set operator container requests a limits                                                                              | _see values.yaml_                    |
+| `eunomia.operator.service.annotaions`        | Set .metadata.annotations for Service                                                                                 | `nil`                                |
+| `eunomia.operator.service.type`              | Set .spec.type for Service                                                                                            | `nil`                                |
+| `eunomia.operator.serviceAccount`            | Name of servie account to run the operator pod                                                                        | `eunomia-operator`                   |
+| `eunomia.operator.tolerations`               | Set `tolerations` field on operator pod spec                                                                          | `nil`                                |
+

--- a/deploy/helm/eunomia-operator/templates/clusterrole-operators.yaml
+++ b/deploy/helm/eunomia-operator/templates/clusterrole-operators.yaml
@@ -36,6 +36,16 @@ rules:
   - '*'
   verbs:
   - '*'
+{{- if .Values.eunomia.operator.podSecurityPolicy.enabled }}
+- apiGroups:
+  - policy
+  resourceNames:
+  - eunomia-operator
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
+{{- end }}
 {{- if .Values.eunomia.operator.openshift.enabled }}
 - apiGroups:
   - template.openshift.io

--- a/deploy/helm/eunomia-operator/templates/podsecuritypolicy.yaml
+++ b/deploy/helm/eunomia-operator/templates/podsecuritypolicy.yaml
@@ -1,0 +1,38 @@
+{{- if .Values.eunomia.operator.podSecurityPolicy.enabled -}}
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: eunomia-operator
+  annotations:
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default,runtime/default'
+    seccomp.security.alpha.kubernetes.io/defaultProfileName:  'runtime/default'
+spec:
+  privileged: false
+  allowPrivilegeEscalation: false
+  requiredDropCapabilities:
+    - ALL
+  volumes:
+    - 'configMap'
+    - 'secret'
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 1
+        max: 65535
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 1
+        max: 65535
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 1
+        max: 65535
+  readOnlyRootFilesystem: true
+{{- end -}}

--- a/deploy/helm/eunomia-operator/values.yaml
+++ b/deploy/helm/eunomia-operator/values.yaml
@@ -15,8 +15,6 @@ eunomia:
       tag: "latest"
       pullPolicy: Always
 
-    imagePullSecrets: []
-
     ingress:
       enabled: false
       annotations: {}

--- a/deploy/helm/eunomia-operator/values.yaml
+++ b/deploy/helm/eunomia-operator/values.yaml
@@ -61,6 +61,10 @@ eunomia:
         cpu: 200m
         memory: 256Mi
 
+    podSecurityPolicy:
+      # Specifies whether PodSecurityPolicy should be created.
+      enabled: false
+
     openshift:
       enabled: false
       route:


### PR DESCRIPTION
**Description**

Creating the PodSecurityPolicy is disabled by default. This can be
overridden in values.yaml or on the command line.

Example:
```
helm template deploy/helm/eunomia-operator/ \
  --set eunomia.operator.image.tag=dev \
  --set eunomia.operator.podSecurityPolicy.enabled=true \
  --set eunomia.operator.image.pullPolicy=Never | kubectl apply -f -
```

<!--
    Please read https://github.com/KohlsTechnology/eunomia/blob/master/.github/CONTRIBUTING.md before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

<!-- Please provide a summary of the change here. -->

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #383 

**Type of change**

<!-- Please delete options that are not relevant. -->

* New feature (non-breaking change which adds functionality)

**Checklist**

- [ ] Unit tests and e2e tests updated
- [ ] Documentation updated
